### PR TITLE
Refactor repository rules to use key-based dictionary format

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,21 @@ coexist in the same directory.
 ```yaml
 structure_rules:
   example_rule:
-    - "LICENSE":
-    - "BUILD": required
-    - 'main\.py'
-    - '[^/]*\.py': optional
+    - p: "LICENSE"
+    - p: "BUILD"
+      required: True
+    - p: 'main\.py'
+    - p: '[^/]*\.py'
+      required: False
 ```
 
-Note that each entry is either a regex pattern only, or a dictionary with a
-regex pattern as the key that contains a value that is one of the following
+Note that each entry requires a key 'p' which contains a regex pattern, for the
+directory entry it matches. An additional key 'required' can be used to specify
+if the entry is required (default) or optional.
 
-- `None`
-- "required"
-- "optional"
-
-So `LICENSE`, `BUILD`, and `main.py` files are required, whereas any Python
-file in the same directory is optional (allowed, but not necessary).
+Thus, in our example above, `LICENSE`, `BUILD`, and `main.py` files are
+required, whereas any Python file in the same directory is optional (allowed,
+but not necessary).
 
 ### Directories
 
@@ -75,13 +75,16 @@ instance
 ```yaml
 structure_rules:
   example_rule_with_directory:
-    - "LICENSE":
-    - "BUILD": required
-    - "main.py"
-    - "library/": optional
+    - p: "LICENSE"
+    - p: "BUILD"
+      required: True
+    - p: "main.py"
+    - p: "library/"
+      required: False
       if_exists:
-        - 'lib\.py'
-        - '[^/]*\.py': optional
+        - p: 'lib\.py'
+        - p: '[^/]*\.py'
+          required: False
 ```
 
 Here, we allow a subdirectory 'library' to exist. We require the file
@@ -96,24 +99,10 @@ key 'use_rule', for example:
 ```yaml
 structure_rules:
   example_rule_with_recursion:
-    - "main.py"
-    - '[^/]*\.py': optional
-    - "library/": # <- Need that colon here
-      use_rule: example_rule_with_recursion
-```
-
-Note that if you want to declare a 'use_rule' key to a directory, you will need
-to declare the directory as a dictionary. Using the shorthand without the colon
-':' would not work.
-
-For instance, this is invalid yaml.
-
-```yaml
-structure_rules:
-  example_rule_with_recursion:
-    - 'main.py'
-    - '[^/]*\.py': optional
-    - 'library/'
+    - p: "main.py"
+    - p: '[^/]*\.py'
+      required: False
+    - p: "library/"
       use_rule: example_rule_with_recursion
 ```
 
@@ -129,10 +118,10 @@ The following example shows a simple template specification
 ```yaml
 templates:
   example_template:
-    - "{{component}}/"
-    - "{{component}}/{{component}}_component.py"
-    - "{{component}}/doc/"
-    - "{{component}}/doc/{{component}}.techspec.md"
+    - p: "{{component}}/"
+    - p: "{{component}}/{{component}}_component.py"
+    - p: "{{component}}/doc/"
+    - p: "{{component}}/doc/{{component}}.techspec.md"
 directory_map:
   /:
     - use_template: example_template
@@ -161,10 +150,10 @@ will permutate through the expansion lists. For example:
 ```yaml
 templates:
   example_template:
-    - "{{component}}/"
-    - "{{component}}/{{component}}_component.{{extension}}"
-    - "{{component}}/doc/"
-    - "{{component}}/doc/{{component}}.techspec.md"
+    - p: "{{component}}/"
+    - p: "{{component}}/{{component}}_component.{{extension}}"
+    - p: "{{component}}/doc/"
+    - p: "{{component}}/doc/{{component}}.techspec.md"
 directory_map:
   /:
     - use_template: example_template
@@ -195,15 +184,19 @@ For example:
 ```yaml
 structure_rules:
   basic_rule:
-    - "LICENSE":
-    - "BUILD": required
+    - p: "LICENSE"
+    - p: "BUILD"
   python_main:
-    - 'main\.py'
-    - '[^/]*\.py': optional
+    - p: 'main\.py'
+    - p: '[^/]*\.py'
+      required: False
   python_library:
-    - 'lib\.py': required
-    - '[^/]*\.py': optional
-    - "[^/]*/": optional # allow library recursion
+    - p: 'lib\.py'
+    - p: '[^/]*\.py'
+      required: False
+    - p: "[^/]*/"
+      required: False
+      # allow library recursion
       use_rule: python_library
 directory_map:
 "/":

--- a/conflicting_test_config.yaml
+++ b/conflicting_test_config.yaml
@@ -1,6 +1,6 @@
 structure_rules:
   conflicting_test_config.yaml:
-    - "conflicting_test_config.yaml"
+    - p: "conflicting_test_config.yaml"
 
 directory_map:
   /:

--- a/repo_structure_config_test.py
+++ b/repo_structure_config_test.py
@@ -20,30 +20,35 @@ def test_successful_parse():
     test_yaml = r"""
 structure_rules:
   basic_rule:
-    - 'README.md': required
-      # mode: required is default
-    - '[^/]*\.md': optional
-    - '.github/': optional
+    - p: 'README.md'
+      required: True
+    - p: '[^/]*\.md'
+      required: False
+    - p: '.github/'
+      required: False
       if_exists:
-      - 'CODEOWNERS'
+        - p: 'CODEOWNERS'
   recursive_rule:
-    - '[^/]*\.py'
-    - 'package/[^/]*':
+    - p: '[^/]*\.py'
+    - p: 'package/[^/]*'
       use_rule: recursive_rule
 templates:
   software_component:
-    - '{{component_name}}_component.cpp'
-    - '{{component_name}}_component.h'
-    - '{{component_name}}_config.h': optional
-    - '{{component_name}}_factory.cpp'
-    - '{{component_name}}_factory.h'
-    - 'BUILD'
-    - 'README.md'
-    - 'doc/'
-    - 'doc/{{component_name}}.swreq.md'
-    - 'doc/{{component_name}}.techspec.md'
-    - '[^/]*\_test.cpp': optional
-    - 'tests/[^/]*_test.cpp': optional
+    - p: '{{component_name}}_component.cpp'
+    - p: '{{component_name}}_component.h'
+    - p: '{{component_name}}_config.h'
+      required: False
+    - p: '{{component_name}}_factory.cpp'
+    - p: '{{component_name}}_factory.h'
+    - p: 'BUILD'
+    - p: 'README.md'
+    - p: 'doc/'
+    - p: 'doc/{{component_name}}.swreq.md'
+    - p: 'doc/{{component_name}}.techspec.md'
+    - p: '[^/]*\_test.cpp'
+      required: False
+    - p: 'tests/[^/]*_test.cpp'
+      required: False
 directory_map:
   /:
     - use_rule: basic_rule
@@ -66,7 +71,7 @@ def test_fail_parse_dangling_use_rule_in_directory_map():
     test_yaml = r"""
 structure_rules:
   base_structure:
-    - "README.md"
+    - p: "README.md"
 
 directory_map:
   /:
@@ -82,9 +87,10 @@ def test_fail_parse_dangling_use_rule_in_structure_rule():
     test_yaml = r"""
 structure_rules:
   base_structure:
-    - 'README.md'
+    - p: 'README.md'
     # if we use a use_rule, we need to add required/optional, too
-    - 'docs/': required
+    - p: 'docs/'
+      required: True
       use_rule: python_package
 
 directory_map:
@@ -100,10 +106,13 @@ def test_fail_directory_structure_mixing_use_rule_and_files():
     test_config = r"""
 structure_rules:
     package:
-      - "docs/": optional
+      - p: "docs/"
+        required: False
         use_rule: documentation
-      - "docs/[^/]*/": optional
-      - "docs/[^/]/[^/]*": optional
+      - p: "docs/[^/]*/"
+        required: False
+      - p: "docs/[^/]/[^/]*"
+        required: False
 directory_map:
 /:
     - use_rule: package
@@ -117,7 +126,7 @@ def test_fail_parse_bad_key_in_structure_rule():
     test_config = r"""
 structure_rules:
     bad_key_rule:
-      - "README.md": optional
+      - p: "README.md"
         bad_key: '.*\.py'
 directory_map:
 /:
@@ -132,7 +141,7 @@ def test_fail_directory_map_key_in_directory_map():
     test_config = """
 structure_rules:
     correct_rule:
-        - 'unused_file'
+        - p: 'unused_file'
 directory_map:
     /:
         - use_rule: correct_rule
@@ -147,9 +156,10 @@ def test_fail_use_rule_not_recursive():
     config_yaml = r"""
 structure_rules:
     license_rule:
-        - LICENSE
+        - p: 'LICENSE'
     bad_use_rule:
-        - '.*/': optional
+        - p: '.*/'
+          required: False
           use_rule: license_rule
 directory_map:
   /:
@@ -165,7 +175,7 @@ def test_fail_directory_map_missing_trailing_slash():
     config_yaml = r"""
 structure_rules:
     license_rule:
-        - LICENSE
+        - p: LICENSE
 directory_map:
   /:
     - use_rule: license_rule
@@ -181,7 +191,7 @@ def test_fail_directory_map_missing_starting_slash():
     config_yaml = r"""
 structure_rules:
     license_rule:
-        - LICENSE
+        - p: LICENSE
 directory_map:
   /:
     - use_rule: license_rule

--- a/repo_structure_enforcement_test.py
+++ b/repo_structure_enforcement_test.py
@@ -123,7 +123,7 @@ def test_matching_regex():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - '.*\.md'
+    - p: '.*\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -145,10 +145,10 @@ def test_required_dir():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - "LICENSE": required
-    - 'README\.md'
-    - 'python/'
-    - 'python/[^/]*'
+    - p: "LICENSE"
+    - p: 'README\.md'
+    - p: 'python/'
+    - p: 'python/[^/]*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -171,10 +171,10 @@ def test_unspecified_dir():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - "LICENSE": required
-    - "README.md"
-    - "python/"
-    - 'python/[^/]*'
+    - p: "LICENSE"
+    - p: "README.md"
+    - p: "python/"
+    - p: 'python/[^/]*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -194,7 +194,7 @@ def test_missing_root_mapping():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - "irrelevant": required
+      - p: "irrelevant"
 directory_map:
   /some_dir/:
     - use_rule: base_structure
@@ -214,9 +214,9 @@ def test_missing_required_file():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - "LICENSE": required
-    - 'README\.md'
-        # mode: required is default
+    - p: "LICENSE"
+    - p: 'README\.md'
+      # required is default
 directory_map:
   /:
     - use_rule: base_structure
@@ -237,10 +237,10 @@ def test_missing_required_dir():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - "LICENSE": required
-    - 'README\.md'
-    - 'python/'
-    - 'python/[^/]*'
+    - p: "LICENSE"
+    - p: 'README\.md'
+    - p: 'python/'
+    - p: 'python/[^/]*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -261,9 +261,9 @@ def test_multi_use_rule():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - 'README\.md'
+      - p: 'README\.md'
   python_package:
-      - '[^/]*\.py': required
+      - p: '[^/]*\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -283,9 +283,9 @@ def test_multi_use_rule_missing_readme():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - 'README\.md'
+      - p: 'README\.md'
   python_package:
-      - '[^/]*\.py': required
+      - p: '[^/]*\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -306,9 +306,9 @@ def test_multi_use_rule_missing_py_file():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - 'README\.md'
+      - p: 'README\.md'
   python_package:
-      - '.*\.py': required
+      - p: '.*\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -330,8 +330,8 @@ def test_conflicting_file_and_dir_names():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - '[^/]*name[^/]*'
-      - '[^/]*name[^/]*/'
+      - p: '[^/]*name[^/]*'
+      - p: '[^/]*name[^/]*/'
 directory_map:
   /:
     - use_rule: base_structure
@@ -350,7 +350,7 @@ def test_conflicting_dir_name():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - '[^/]*name[^/]*'
+    - p: '[^/]*name[^/]*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -370,7 +370,7 @@ def test_conflicting_file_name():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - '[^/]*name[^/]*/'
+    - p: '[^/]*name[^/]*/'
 directory_map:
   /:
     - use_rule: base_structure
@@ -390,7 +390,7 @@ def test_filename_with_bad_substring_match():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - '[^/]*name'
+    - p: '[^/]*name'
 directory_map:
   /:
     - use_rule: base_structure
@@ -410,8 +410,8 @@ def test_succeed_overlapping_required_file_rules():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'README\.md'
-    - 'README\.[^/]*'
+    - p: 'README\.md'
+    - p: 'README\.[^/]*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -430,10 +430,11 @@ def test_required_file_in_optional_directory_no_entry():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'LICENSE'
-    - 'doc/': optional
+    - p: 'LICENSE'
+    - p: 'doc/'
+      required: False
       if_exists:
-        - 'README\.md': required
+        - p: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -453,10 +454,11 @@ def test_required_file_in_optional_directory_with_entry():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'LICENSE'
-    - 'doc/': optional
+    - p: 'LICENSE'
+    - p: 'doc/'
+      required: False
       if_exists:
-        - 'README\.md': required
+        - p: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -478,10 +480,11 @@ def test_required_file_in_optional_directory_with_entry_and_exists():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'LICENSE'
-    - 'doc/': optional
+    - p: 'LICENSE'
+    - p: 'doc/'
+      required: False
       if_exists:
-        - 'README\.md': required
+        - p: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -503,10 +506,11 @@ def test_use_rule_recursive():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'README\.md'
+    - p: 'README\.md'
   cpp_source:
-    - '[^/]*\.cpp': required
-    - '[^/]*/': optional
+    - p: '[^/]*\.cpp'
+    - p: '[^/]*/'
+      required: False
       use_rule: cpp_source
 directory_map:
   /:
@@ -530,10 +534,11 @@ def test_fail_use_rule_recursive():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'README\.md'
+    - p: 'README\.md'
   python_package:
-    - '[^/]*\.py': required
-    - '[^/]*/': optional
+    - p: '[^/]*\.py'
+    - p: '[^/]*/'
+      required: False
       use_rule: python_package
 directory_map:
   /:
@@ -558,10 +563,11 @@ def test_fail_directory_mapping_precedence():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'README\.md'
+    - p: 'README\.md'
   python_package:
-    - '[^/]*\.py': required
-    - '[^/]*': optional
+    - p: '[^/]*\.py'
+    - p: '[^/]*'
+      required: False
       use_rule: python_package
 directory_map:
   /:
@@ -593,11 +599,13 @@ def test_succeed_elaborate_use_rule_recursive():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'README\.md'
-    - app/: optional
+    - p: 'README\.md'
+    - p: app/
+      required: False
   python_package:
-    - '[^/]*\.py': required
-    - '[^/]*/': optional
+    - p: '[^/]*\.py'
+    - p: '[^/]*/'
+      required: False
       use_rule: python_package
 directory_map:
   /:
@@ -623,7 +631,7 @@ def test_succeed_ignored_hidden_file():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'README\.md'
+    - p: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -644,8 +652,8 @@ def test_fail_hidden_file_required_despite_hidden_disabled():
     config_yaml = r"""
 structure_rules:
   base_structure:
-     - '\.hidden\.md'
-     - 'README\.md'
+     - p: '\.hidden\.md'
+     - p: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -669,8 +677,8 @@ def test_fail_unspecified_hidden_files_when_hidden_enabled():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - '\.hidden.md'
-    - 'README\.md'
+    - p: '\.hidden.md'
+    - p: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -694,7 +702,7 @@ def test_succeed_gitignored_file():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'README\.md'
+    - p: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -714,7 +722,7 @@ def test_fail_unspecified_link():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'README\.md'
+    - p: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -737,8 +745,8 @@ def test_succeed_specified_link():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - 'README\.md'
-    - 'link'
+    - p: 'README\.md'
+    - p: 'link'
 directory_map:
   /:
     - use_rule: base_structure
@@ -766,10 +774,10 @@ def test_succeed_template_rule():
     config_yaml = r"""
 templates:
   component:
-    - '{{component}}/'
-    - '{{component}}/{{component}}_component.py'
-    - '{{component}}/doc/'
-    - '{{component}}/doc/{{component}}.techspec.md'
+    - p: '{{component}}/'
+    - p: '{{component}}/{{component}}_component.py'
+    - p: '{{component}}/doc/'
+    - p: '{{component}}/doc/{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -795,10 +803,10 @@ def test_fail_template_rule_missing_file():
     config_yaml = r"""
 templates:
   component:
-    - '{{component}}/'
-    - '{{component}}/{{component}}_component.py'
-    - '{{component}}/doc/'
-    - '{{component}}/doc/{{component}}.techspec.md'
+    - p: '{{component}}/'
+    - p: '{{component}}/{{component}}_component.py'
+    - p: '{{component}}/doc/'
+    - p: '{{component}}/doc/{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -825,11 +833,12 @@ def test_succeed_template_rule_if_exists():
     config_yaml = r"""
 templates:
   component:
-    - '{{component}}/'
-    - '{{component}}/{{component}}_component.py'
-    - '{{component}}/doc/': optional
+    - p: '{{component}}/'
+    - p: '{{component}}/{{component}}_component.py'
+    - p: '{{component}}/doc/'
+      required: False
       if_exists:
-        - '{{component}}.techspec.md'
+        - p: '{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -864,10 +873,10 @@ def test_succeed_template_rule_subdirectory_map():
     config_yaml = r"""
 templates:
   component:
-    - '{{component}}/'
-    - '{{component}}/{{component}}_component.py'
-    - '{{component}}/doc/'
-    - '{{component}}/doc/{{component}}.techspec.md'
+    - p: '{{component}}/'
+    - p: '{{component}}/{{component}}_component.py'
+    - p: '{{component}}/doc/'
+    - p: '{{component}}/doc/{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -904,10 +913,10 @@ def test_fail_template_rule_subdirectory_map_missing_file():
     config_yaml = r"""
 templates:
   component:
-    - '{{component}}/'
-    - '{{component}}/{{component}}_component.py'
-    - '{{component}}/doc/'
-    - '{{component}}/doc/{{component}}.techspec.md'
+    - p: '{{component}}/'
+    - p: '{{component}}/{{component}}_component.py'
+    - p: '{{component}}/doc/'
+    - p: '{{component}}/doc/{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -946,10 +955,10 @@ def test_succeed_template_rule_multiple_expansions():
     config_yaml = r"""
 templates:
   example_template:
-    - '{{component}}/'
-    - '{{component}}/{{component}}_component.{{extension}}'
-    - '{{component}}/doc/'
-    - '{{component}}/doc/{{component}}.techspec.md'
+    - p: '{{component}}/'
+    - p: '{{component}}/{{component}}_component.{{extension}}'
+    - p: '{{component}}/doc/'
+    - p: '{{component}}/doc/{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: example_template


### PR DESCRIPTION
Switching (half) back to full dictionaries instead of dynamic usage of dict and str.
Seems to be the much better alternative to the dynamic parsing before