### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/poetry-ci.yaml
+++ b/.github/workflows/poetry-ci.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         poetry-version: ["1.8.4"]
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/.github/workflows/poetry-ci.yaml
+++ b/.github/workflows/poetry-ci.yaml
@@ -1,0 +1,37 @@
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        poetry-version: ["1.7.1", "1.8.4"]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run image
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: ${{ matrix.poetry-version }}
+      - name: View poetry --help
+        run: |
+          poetry install
+          poetry run pytest --cov --cov-report xml:coverage.xml
+      - name: Get Coverage
+        uses: orgoro/coverage@v3.2
+        with:
+          coverageFile: coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/poetry-ci.yaml
+++ b/.github/workflows/poetry-ci.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        poetry-version: ["1.7.1", "1.8.4"]
+        poetry-version: ["1.8.4"]
         os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "102bbee94061ff02fd361ec29c27b7cb26582f5f" # frozen: v1.12.1
+    rev: "f56614daa94d5cd733d3b7004c5df9caad267b4a" # frozen: v1.13.0
     hooks:
       - id: mypy
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -54,11 +54,11 @@ repos:
       - id: detect-secrets
         exclude: .pre-commit-config.yaml
   - repo: https://github.com/zricethezav/gitleaks
-    rev: "bdca2e2df71555f58d8ab30f05ef93c6bd91a5a4" # frozen: v8.21.1
+    rev: "77c3c6a34b2577d71083442326c60b8fd58926ec" # frozen: v8.18.4
     hooks:
       - id: gitleaks
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "8983acb92ee4b01924893632cf90af926fa608f0" # frozen: v0.7.0
+    rev: "4edcbde74af0cd9b38e8483828cd9c6cb0755276" # frozen: v0.7.1
     hooks:
       - id: ruff
   - repo: https://github.com/python-poetry/poetry

--- a/repo_structure/__main__.py
+++ b/repo_structure/__main__.py
@@ -48,5 +48,7 @@ def main(
         sys.exit(1)
 
 
+# The following main check is very hard to get into unit
+# testing and as long as it contains so little code, we'll skip it.
 if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
Introduce a new GitHub Actions workflow for continuous integration using Poetry across multiple Python versions and operating systems. Annotate the main entry point in `__main__.py` to skip coverage analysis, as it is difficult to unit test the entry block.