### PR TITLE
Update repo_structure commands in pre-commit config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,14 +16,14 @@
   stages: [pre-push, manual]
 - id: repo-structure-diff-scan
   name: Enforce Repository Structure
-  entry: repo_structure diff-scan --repo-root .
+  entry: repo_structure diff-scan
   description: Ensuring the repository structure matches the specification from the configuration file
   language: python
   pass_filenames: false
   args: ["--config-path", "repo_structure.yaml"]
 - id: repo-structure-diff-scan-debug
   name: Enforce Repository Structure
-  entry: repo_structure --verbose diff-scan --repo-root .
+  entry: repo_structure --verbose diff-scan
   description: Ensuring the repository structure matches the specification from the configuration file
   language: python
   pass_filenames: false


### PR DESCRIPTION
diff-scan does not require the `--repo-root` option and will fail if it's provided