### PR TITLE
Parallelize full scan of repository

### DIFF
--- a/.github/workflows/poetry-ci.yaml
+++ b/.github/workflows/poetry-ci.yaml
@@ -26,12 +26,14 @@ jobs:
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: ${{ matrix.poetry-version }}
+      - name: Run poetry install
+        run: |
+          poetry install
       - name: Run repo_structure full-scan with poetry
         run: |
           poetry run python -m repo_structure full-scan --repo-root=. --config-path=repo_structure.yaml
       - name: Run poetry pytest
         run: |
-          poetry install
           poetry run pytest --cov --cov-report xml:coverage.xml
       - name: Get Coverage
         uses: orgoro/coverage@v3.2

--- a/.github/workflows/poetry-ci.yaml
+++ b/.github/workflows/poetry-ci.yaml
@@ -26,6 +26,9 @@ jobs:
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: ${{ matrix.poetry-version }}
+      - name: Run repo_structure full-scan with poetry
+        run: |
+          poetry run python -m repo_structure full-scan --repo-root=. --config-path=repo_structure.yaml
       - name: Run poetry pytest
         run: |
           poetry install
@@ -35,6 +38,3 @@ jobs:
         with:
           coverageFile: coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run repo_structure full-scan with poetry
-        run: |
-          poetry run python -m repo_structure full-scan --repo-root=. --config-path=repo_structure.yaml

--- a/repo_structure/repo_structure_enforcement.py
+++ b/repo_structure/repo_structure_enforcement.py
@@ -7,6 +7,7 @@ import re
 from os import DirEntry
 from dataclasses import dataclass, replace
 
+from concurrent.futures import ProcessPoolExecutor
 from typing import List, Callable, Optional, Union, Iterator, Tuple
 from gitignore_parser import parse_gitignore
 
@@ -241,6 +242,23 @@ def _map_dir_to_entry_backlog(
     return _build_active_entry_backlog(use_rules, map_dir, config)
 
 
+def _process_map_dir(
+    map_dir: str, repo_root: str, config: Configuration, flags: Optional[Flags]
+):
+    """Process a single map directory entry."""
+    rel_dir = map_dir_to_rel_dir(map_dir)
+    backlog = _map_dir_to_entry_backlog(config, rel_dir)
+
+    _fail_if_invalid_repo_structure_recursive(
+        repo_root,
+        rel_dir,
+        config,
+        backlog,
+        flags or Flags(),
+    )
+    _fail_if_required_entries_missing(backlog)
+
+
 def assert_full_repository_structure(
     repo_root: str,
     config: Configuration,
@@ -252,18 +270,15 @@ def assert_full_repository_structure(
     if "/" not in config.directory_map:
         raise MissingMappingError("Config does not have a root mapping")
 
-    for map_dir in config.directory_map:
-        rel_dir = map_dir_to_rel_dir(map_dir)
-        backlog = _map_dir_to_entry_backlog(config, rel_dir)
+    with ProcessPoolExecutor() as executor:
+        futures = [
+            executor.submit(_process_map_dir, map_dir, repo_root, config, flags)
+            for map_dir in config.directory_map
+        ]
 
-        _fail_if_invalid_repo_structure_recursive(
-            repo_root,
-            rel_dir,
-            config,
-            backlog,
-            flags or Flags(),
-        )
-        _fail_if_required_entries_missing(backlog)
+        # Wait for all tasks to complete
+        for future in futures:
+            future.result()
 
 
 def _incremental_path_split(path_to_split: str) -> Iterator[Tuple[str, bool]]:

--- a/repo_structure/repo_structure_enforcement.py
+++ b/repo_structure/repo_structure_enforcement.py
@@ -147,6 +147,7 @@ def _handle_if_exists(
     backlog: StructureRuleList, backlog_entry: RepoEntry, rel_path: str, flags: Flags
 ):
     if backlog_entry.if_exists:
+        # TODO(nesono): move this to parsing instead
         if not backlog_entry.is_dir:
             raise EntryTypeMismatchError(
                 f"'if_exists' only allowed with files, but found with {backlog_entry.path.pattern}"


### PR DESCRIPTION
Simple parallelization based on map_dir - makes the scan twice as fast roughly.
Note that the tests now take quite a bit longer due to the constant processing pool creation and teardown.