### PR TITLE
Update regex patterns and test with job parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A basic consumption looks like the following.
 ```yaml
 repos:
   - repo: https://github.com/nesono/repo_structure
-    rev: "v0.3.0"
+    rev: "v0.3.1"
     hooks:
       - id: repo-structure-diff-scan
 ```
@@ -42,7 +42,7 @@ to the yaml, for instance:
 ```yaml
 repos:
   - repo: https://github.com/nesono/repo_structure
-    rev: "v0.3.0"
+    rev: "v0.3.1"
     hooks:
       - id: repo-structure-diff-scan
         args: ["--config-path", "path/to/your_config_file.yaml"]
@@ -96,7 +96,7 @@ structure_rules:
     - p: "BUILD"
       required: True
     - p: 'main\.py'
-    - p: '.*\.py'
+    - p: '[^/]*?\.py'
       required: False
 ```
 
@@ -124,13 +124,25 @@ structure_rules:
       required: False
       if_exists:
         - p: 'lib\.py'
-        - p: '.*\.py'
+        - p: '[^/]*?\.py'
           required: False
 ```
 
 Here, we allow a subdirectory 'library' to exist. We require the file
 'library/lib.py' if the folder 'library' exists. Any other file ending on '.py'
 is allowed in it as well, but not required.
+
+### Important Note on Patterns
+
+It's very important to note that the patterns have a very strong effect on the
+overall execution time of the tool. Therefore, make sure to use minimal
+patterns, i.e. that are not greedy.
+
+For example, do NOT use `.*` as a wildcard pattern to match any file or
+directory name, but instead use `[^/]*?`.
+
+Make sure you keep this in mind, since using the wrong patterns can result
+in a tool **that does not seem to finish processing**.
 
 ### Recursion
 
@@ -141,7 +153,7 @@ key 'use_rule', for example:
 structure_rules:
   example_rule_with_recursion:
     - p: "main\.py"
-    - p: '.*\.py'
+    - p: '[^/]*?\.py'
       required: False
     - p: "library/"
       use_rule: example_rule_with_recursion
@@ -236,13 +248,13 @@ structure_rules:
     - p: "BUILD"
   python_main:
     - p: 'main\.py'
-    - p: '.*\.py'
+    - p: '[^/]*?\.py'
       required: False
   python_library:
     - p: 'lib\.py'
-    - p: '.*\.py'
+    - p: '[^/]*?\.py'
       required: False
-    - p: ".*/"
+    - p: "[^/]*?/"
       required: False
       # allow library recursion
       use_rule: python_library

--- a/repo_structure/__main___test.py
+++ b/repo_structure/__main___test.py
@@ -11,6 +11,8 @@ def test_main_full_scan_success():
         repo_structure,
         [
             "--verbose",
+            "--jobs",
+            "0",
             "full-scan",
             "-r",
             ".",
@@ -27,7 +29,15 @@ def test_main_full_scan_fail_bad_config():
     runner = CliRunner()
     result = runner.invoke(
         repo_structure,
-        ["full-scan", "-r", ".", "-c", "repo_structure/test_config_bad_config.yaml"],
+        [
+            "--jobs",
+            "1",
+            "full-scan",
+            "-r",
+            ".",
+            "-c",
+            "repo_structure/test_config_bad_config.yaml",
+        ],
     )
 
     assert result.exit_code != 0

--- a/repo_structure/repo_structure_config_test.py
+++ b/repo_structure/repo_structure_config_test.py
@@ -169,10 +169,10 @@ structure_rules:
       required: False
       use_rule: documentation
       if_exists:
-      - p: ".*/"
+      - p: "[^/]*?/"
         required: False
         if_exists:
-        - p: ".*"
+        - p: "[^/]*?"
           required: False
 directory_map:
   /:
@@ -188,7 +188,7 @@ def test_fail_parse_bad_key_in_structure_rule():
 structure_rules:
   bad_key_rule:
     - p: "README.md"
-      bad_key: '.*\.py'
+      bad_key: '[^/]*?\.py'
 directory_map:
   /:
     - use_rule: bad_key_rule
@@ -233,7 +233,7 @@ structure_rules:
     license_rule:
         - p: 'LICENSE'
     bad_use_rule:
-        - p: '.*/'
+        - p: '[^/]*?/'
           required: False
           use_rule: license_rule
 directory_map:

--- a/repo_structure/repo_structure_enforcement_test.py
+++ b/repo_structure/repo_structure_enforcement_test.py
@@ -117,7 +117,7 @@ def test_matching_regex():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: '.*\.md'
+    - p: '[^/]*?\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -141,7 +141,7 @@ structure_rules:
     - p: 'README\.md'
     - p: 'python/'
       if_exists:
-      - p: '.*\.py'
+      - p: '[^/]*?\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -166,7 +166,7 @@ structure_rules:
     - p: "README.md"
     - p: "python/"
       if_exists:
-      - p: '.*'
+      - p: '[^/]*?'
 directory_map:
   /:
     - use_rule: base_structure
@@ -230,7 +230,7 @@ structure_rules:
     - p: 'README\.md'
     - p: 'python/'
       if_exists:
-      - p: '.*'
+      - p: '[^/]*?'
 directory_map:
   /:
     - use_rule: base_structure
@@ -253,7 +253,7 @@ structure_rules:
   base_structure:
       - p: 'README\.md'
   python_package:
-      - p: '.*\.py'
+      - p: '[^/]*?\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -275,7 +275,7 @@ structure_rules:
   base_structure:
       - p: 'README\.md'
   python_package:
-      - p: '.*\.py'
+      - p: '[^/]*?\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -297,10 +297,10 @@ def test_conflicting_file_and_dir_names():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - p: '.*name.*'
-      - p: '.*name.*/'
+      - p: '[^/]*?name[^/]*?'
+      - p: '[^/]*?name[^/]*?/'
         if_exists:
-        - p: '.*'
+        - p: '[^/]*?'
           required: False
 directory_map:
   /:
@@ -320,7 +320,7 @@ def test_conflicting_dir_name():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: '.*name.*'
+    - p: '[^/]*?name[^/]*?'
 directory_map:
   /:
     - use_rule: base_structure
@@ -340,9 +340,9 @@ def test_conflicting_file_name():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: '.*name.*/'
+    - p: '[^/]*?name[^/]*?/'
       if_exists:
-      - p: '.*'
+      - p: '[^/]*?'
       required: False
 directory_map:
   /:
@@ -363,7 +363,7 @@ def test_filename_with_bad_substring_match():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: '.*name'
+    - p: '[^/]*?name'
 directory_map:
   /:
     - use_rule: base_structure
@@ -384,7 +384,7 @@ def test_succeed_overlapping_required_file_rules():
 structure_rules:
   base_structure:
     - p: 'README\.md'
-    - p: 'README\..*'
+    - p: 'README\.[^/]*?'
 directory_map:
   /:
     - use_rule: base_structure
@@ -481,8 +481,8 @@ structure_rules:
   base_structure:
     - p: 'README\.md'
   cpp_source:
-    - p: '.*\.cpp'
-    - p: '.*/'
+    - p: '[^/]*?\.cpp'
+    - p: '[^/]*?/'
       required: False
       use_rule: cpp_source
 directory_map:
@@ -509,8 +509,8 @@ structure_rules:
   base_structure:
     - p: 'README\.md'
   python_package:
-    - p: '.*\.py'
-    - p: '.*/'
+    - p: '[^/]*?\.py'
+    - p: '[^/]*?/'
       required: False
       use_rule: python_package
 directory_map:
@@ -538,8 +538,8 @@ structure_rules:
   base_structure:
     - p: 'README\.md'
   python_package:
-    - p: '.*\.py'
-    - p: '.*/'
+    - p: '[^/]*?\.py'
+    - p: '[^/]*?/'
       required: False
       use_rule: python_package
 directory_map:
@@ -574,8 +574,8 @@ structure_rules:
   base_structure:
     - p: 'README\.md'
   python_package:
-    - p: '.*\.py'
-    - p: '.*/'
+    - p: '[^/]*?\.py'
+    - p: '[^/]*?/'
       required: False
       use_rule: python_package
 directory_map:


### PR DESCRIPTION
Make usage of regex patterns more clear.

It turned out that using too greedy patterns can cause severe performance issues with the tool