### PR TITLE
Support for forbidden entries in repo_structure scans

### DIFF
--- a/repo_structure/repo_structure_config_test.py
+++ b/repo_structure/repo_structure_config_test.py
@@ -40,8 +40,8 @@ templates:
     - require: 'README.md'
     - require: 'doc/'
       if_exists:
-      - p: '{{component_name}}.swreq.md'
-      - p: '{{component_name}}.techspec.md'
+      - require: '{{component_name}}.swreq.md'
+      - require: '{{component_name}}.techspec.md'
     - allow: '.*\_test.cpp'
     - allow: 'tests/.*_test.cpp'
 directory_map:
@@ -73,7 +73,7 @@ def test_fail_parse_bad_pattern():
     test_yaml = r"""
 structure_rules:
   bad_pattern_rule:
-    - p: "[^]*.md"
+    - require: "[^]*.md"
 
 directory_map:
   /:
@@ -89,7 +89,7 @@ def test_fail_parse_bad_schema():
     test_yaml = r"""
 structure_rules:
   base_structure:
-    - p: "README.md"
+    - require: "README.md"
 
 directory_map:
   /:
@@ -124,7 +124,7 @@ def test_fail_parse_dangling_use_rule_in_directory_map():
     test_yaml = r"""
 structure_rules:
   base_structure:
-    - p: "README.md"
+    - require: "README.md"
 
 directory_map:
   /:
@@ -140,10 +140,8 @@ def test_fail_parse_dangling_use_rule_in_structure_rule():
     test_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README.md'
-    # if we use a use_rule, we need to add required/optional, too
-    - p: 'docs/'
-      required: True
+    - require: 'README.md'
+    - allow: 'docs/'
       use_rule: python_package
 
 directory_map:
@@ -159,15 +157,12 @@ def test_fail_directory_structure_mixing_use_rule_and_files():
     test_config = r"""
 structure_rules:
   package:
-    - p: "docs/"
-      required: False
+    - allow: "docs/"
       use_rule: documentation
       if_exists:
-      - p: ".*/"
-        required: False
+      - allow: ".*/"
         if_exists:
-        - p: ".*"
-          required: False
+        - allow: ".*"
 directory_map:
   /:
     - use_rule: package
@@ -181,7 +176,7 @@ def test_fail_parse_bad_key_in_structure_rule():
     test_config = r"""
 structure_rules:
   bad_key_rule:
-    - p: "README.md"
+    - require: "README.md"
       bad_key: '.*\.py'
 directory_map:
   /:
@@ -196,7 +191,7 @@ def test_fail_directory_map_key_in_directory_map():
     test_config = """
 structure_rules:
     correct_rule:
-        - p: 'unused_file'
+        - require: 'unused_file'
 directory_map:
     /:
         - foo: documentation
@@ -210,7 +205,7 @@ def test_fail_directory_map_additional_key_in_directory_map():
     test_config = """
 structure_rules:
     correct_rule:
-        - p: 'unused_file'
+        - require: 'unused_file'
 directory_map:
     /:
         - use_rule: correct_rule
@@ -225,10 +220,9 @@ def test_fail_use_rule_not_recursive():
     config_yaml = r"""
 structure_rules:
     license_rule:
-        - p: 'LICENSE'
+        - require: 'LICENSE'
     bad_use_rule:
-        - p: '.*/'
-          required: False
+        - allow: '.*/'
           use_rule: license_rule
 directory_map:
   /:
@@ -244,7 +238,7 @@ def test_fail_directory_map_missing_trailing_slash():
     config_yaml = r"""
 structure_rules:
     license_rule:
-        - p: LICENSE
+        - require: LICENSE
 directory_map:
   /:
     - use_rule: license_rule
@@ -260,7 +254,7 @@ def test_fail_directory_map_missing_starting_slash():
     config_yaml = r"""
 structure_rules:
     license_rule:
-        - p: LICENSE
+        - require: LICENSE
 directory_map:
   /:
     - use_rule: license_rule
@@ -276,7 +270,7 @@ def test_fail_use_template_missing_parameters():
     test_config = """
 templates:
     some_template:
-        - p: '{{parameter_name}}.md'
+        - require: '{{parameter_name}}.md'
 directory_map:
     /:
         - use_template: some_template
@@ -290,7 +284,7 @@ def test_fail_use_template_parameters_not_arrays():
     test_config = """
 templates:
     some_template:
-        - p: '{{parameter_name}}.md'
+        - require: '{{parameter_name}}.md'
 directory_map:
     /:
         - use_template: some_template
@@ -305,7 +299,7 @@ def test_fail_use_template_parameters_with_use_rule():
     test_config = """
 structure_rules:
     correct_rule:
-        - p: 'some_file.md'
+        - require: 'some_file.md'
 directory_map:
     /:
         - use_rule: correct_rule
@@ -320,7 +314,7 @@ def test_fail_double_underscore_prefix_structure_rule():
     test_config = """
 structure_rules:
     __incorrect_rule:
-        - p: 'some_file.md'
+        - require: 'some_file.md'
 directory_map:
     /:
         - use_rule: __incorrect_rule
@@ -334,7 +328,7 @@ def test_fail_double_underscore_prefix_template():
     test_config = """
 templates:
     __incorrect_template:
-        - p: '{{parameter}}_some_file.md'
+        - require: '{{parameter}}_some_file.md'
 directory_map:
     /:
         - use_rule: __incorrect_template

--- a/repo_structure/repo_structure_diff_scan.py
+++ b/repo_structure/repo_structure_diff_scan.py
@@ -22,6 +22,7 @@ from .repo_structure_lib import (
     _map_dir_to_entry_backlog,
     StructureRuleList,
     UnspecifiedEntryError,
+    ForbiddenEntryError,
 )
 
 
@@ -113,4 +114,8 @@ def assert_path(
     except UnspecifiedEntryError as err:
         raise UnspecifiedEntryError(
             f"Unspecified entry {path} found. Map dir: {map_dir}"
+        ) from err
+    except ForbiddenEntryError as err:
+        raise ForbiddenEntryError(
+            f"Forbidden entry {path} found. Map dir: {map_dir}"
         ) from err

--- a/repo_structure/repo_structure_diff_scan_test.py
+++ b/repo_structure/repo_structure_diff_scan_test.py
@@ -64,9 +64,9 @@ def test_multi_use_rule():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - p: 'README\.md'
+      - require: 'README\.md'
   python_package:
-      - p: '.*\.py'
+      - require: '.*\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -82,9 +82,9 @@ def test_multi_use_rule_fail():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - p: 'README\.md'
+      - require: 'README\.md'
   python_package:
-      - p: '.*\.py'
+      - require: '.*\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -101,11 +101,10 @@ def test_use_rule_recursive():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
+    - require: 'README\.md'
   cpp_source:
-    - p: '.*\.cpp'
-    - p: '.*/'
-      required: False
+    - require: '.*\.cpp'
+    - allow: '.*/'
       use_rule: cpp_source
 directory_map:
   /:
@@ -125,11 +124,10 @@ def test_succeed_elaborate_use_rule_recursive():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
+    - require: 'README\.md'
   python_package:
-    - p: '.*\.py'
-    - p: '.*/'
-      required: False
+    - require: '.*\.py'
+    - allow: '.*/'
       use_rule: python_package
 directory_map:
   /:

--- a/repo_structure/repo_structure_diff_scan_test.py
+++ b/repo_structure/repo_structure_diff_scan_test.py
@@ -5,7 +5,7 @@
 import pytest
 
 
-from .repo_structure_lib import UnspecifiedEntryError, Flags
+from .repo_structure_lib import UnspecifiedEntryError, Flags, ForbiddenEntryError
 from .repo_structure_config import Configuration
 from .repo_structure_diff_scan import assert_path
 
@@ -24,6 +24,21 @@ directory_map:
     assert_path(config, "README.md")
     with pytest.raises(UnspecifiedEntryError):
         assert_path(config, "bad_filename.md")
+
+
+def test_forbidden_entry():
+    """Test with forbidden file."""
+    config_yaml = r"""
+structure_rules:
+  base_structure:
+    - forbid: 'CMakeLists\.txt'
+directory_map:
+  /:
+    - use_rule: base_structure
+    """
+    config = Configuration(config_yaml, True)
+    with pytest.raises(ForbiddenEntryError):
+        assert_path(config, "CMakeLists.txt")
 
 
 def test_matching_regex_dir():

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -7,7 +7,7 @@ import os
 from typing import List, Callable, Optional, Union
 from gitignore_parser import parse_gitignore
 
-from .repo_structure_lib import Flags, UnspecifiedEntryError
+from .repo_structure_lib import Flags, UnspecifiedEntryError, ForbiddenEntryError
 from .repo_structure_config import (
     Configuration,
 )
@@ -110,6 +110,10 @@ def _fail_if_invalid_repo_structure_recursive(
         except UnspecifiedEntryError as err:
             raise UnspecifiedEntryError(
                 f"Unspecified entry found: '{entry.rel_dir}/{entry.path}'"
+            ) from err
+        except ForbiddenEntryError as err:
+            raise ForbiddenEntryError(
+                f"Forbidden entry found: '{entry.rel_dir}/{entry.path}'"
             ) from err
 
         for idx in indices:

--- a/repo_structure/repo_structure_full_scan_test.py
+++ b/repo_structure/repo_structure_full_scan_test.py
@@ -28,9 +28,7 @@ def _get_tmp_dir() -> str:
 
 
 def _remove_tmp_dir(tmpdir: str) -> None:
-    # if TEST_TMPDIR is there, bazel will take care of it, otherwise:
-    if "TEST_TMPDIR" not in os.environ:
-        shutil.rmtree(tmpdir)
+    shutil.rmtree(tmpdir)
 
 
 def _create_repo_directory_structure(specification: str) -> None:

--- a/repo_structure/repo_structure_full_scan_test.py
+++ b/repo_structure/repo_structure_full_scan_test.py
@@ -120,7 +120,7 @@ def test_matching_regex():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: '.*\.md'
+    - require: '.*\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -141,10 +141,10 @@ def test_required_dir():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
-    - p: 'python/'
+    - require: 'README\.md'
+    - require: 'python/'
       if_exists:
-      - p: '.*\.py'
+      - require: '.*\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -166,10 +166,10 @@ def test_unspecified_dir():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: "README.md"
-    - p: "python/"
+    - require: "README.md"
+    - require: "python/"
       if_exists:
-      - p: '.*'
+      - require: '.*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -189,7 +189,7 @@ def test_missing_root_mapping():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - p: "irrelevant"
+      - require: "irrelevant"
 directory_map:
   /some_dir/:
     - use_rule: base_structure
@@ -209,8 +209,8 @@ def test_missing_required_file():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: "LICENSE"
-    - p: 'README\.md'
+    - require: "LICENSE"
+    - require: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -230,10 +230,10 @@ def test_missing_required_dir():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
-    - p: 'python/'
+    - require: 'README\.md'
+    - require: 'python/'
       if_exists:
-      - p: '.*'
+      - require: '.*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -254,9 +254,9 @@ def test_multi_use_rule():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - p: 'README\.md'
+      - require: 'README\.md'
   python_package:
-      - p: '.*\.py'
+      - require: '.*\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -276,9 +276,9 @@ def test_multi_use_rule_missing_py_file():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - p: 'README\.md'
+      - require: 'README\.md'
   python_package:
-      - p: '.*\.py'
+      - require: '.*\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -300,11 +300,10 @@ def test_conflicting_file_and_dir_names():
     config_yaml = r"""
 structure_rules:
   base_structure:
-      - p: '.*name.*'
-      - p: '.*name.*/'
+      - require: '.*name.*'
+      - require: '.*name.*/'
         if_exists:
-        - p: '.*'
-          required: False
+        - allow: '.*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -323,7 +322,7 @@ def test_conflicting_dir_name():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: '.*name.*'
+    - require: '.*name.*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -343,10 +342,9 @@ def test_conflicting_file_name():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: '.*name.*/'
+    - require: '.*name.*/'
       if_exists:
-      - p: '.*'
-      required: False
+      - allow: '.*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -366,7 +364,7 @@ def test_filename_with_bad_substring_match():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: '.*name'
+    - require: '.*name'
 directory_map:
   /:
     - use_rule: base_structure
@@ -386,8 +384,8 @@ def test_succeed_overlapping_required_file_rules():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
-    - p: 'README\..*'
+    - require: 'README\.md'
+    - require: 'README\..*'
 directory_map:
   /:
     - use_rule: base_structure
@@ -406,11 +404,10 @@ def test_required_file_in_optional_directory_no_entry():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'LICENSE'
-    - p: 'doc/'
-      required: False
+    - require: 'LICENSE'
+    - allow: 'doc/'
       if_exists:
-        - p: 'README\.md'
+        - require: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -430,11 +427,10 @@ def test_required_file_in_optional_directory_with_entry():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'LICENSE'
-    - p: 'doc/'
-      required: False
+    - require: 'LICENSE'
+    - allow: 'doc/'
       if_exists:
-        - p: 'README\.md'
+        - require: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -456,11 +452,10 @@ def test_required_file_in_optional_directory_with_entry_and_exists():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'LICENSE'
-    - p: 'doc/'
-      required: False
+    - require: 'LICENSE'
+    - allow: 'doc/'
       if_exists:
-        - p: 'README\.md'
+        - require: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -482,11 +477,10 @@ def test_use_rule_recursive():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
+    - require: 'README\.md'
   cpp_source:
-    - p: '.*\.cpp'
-    - p: '.*/'
-      required: False
+    - require: '.*\.cpp'
+    - allow: '.*/'
       use_rule: cpp_source
 directory_map:
   /:
@@ -510,11 +504,10 @@ def test_fail_use_rule_recursive():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
+    - require: 'README\.md'
   python_package:
-    - p: '.*\.py'
-    - p: '.*/'
-      required: False
+    - require: '.*\.py'
+    - require: '.*/'
       use_rule: python_package
 directory_map:
   /:
@@ -539,11 +532,10 @@ def test_fail_directory_mapping_precedence():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
+    - require: 'README\.md'
   python_package:
-    - p: '.*\.py'
-    - p: '.*/'
-      required: False
+    - require: '.*\.py'
+    - allow: '.*/'
       use_rule: python_package
 directory_map:
   /:
@@ -575,11 +567,10 @@ def test_succeed_elaborate_use_rule_recursive():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
+    - require: 'README\.md'
   python_package:
-    - p: '.*\.py'
-    - p: '.*/'
-      required: False
+    - require: '.*\.py'
+    - allow: '.*/'
       use_rule: python_package
 directory_map:
   /:
@@ -605,7 +596,7 @@ def test_succeed_ignored_hidden_file():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
+    - require: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -626,8 +617,8 @@ def test_fail_hidden_file_required_despite_hidden_disabled():
     config_yaml = r"""
 structure_rules:
   base_structure:
-     - p: '\.hidden\.md'
-     - p: 'README\.md'
+     - require: '\.hidden\.md'
+     - require: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -651,8 +642,8 @@ def test_fail_unspecified_hidden_files_when_hidden_enabled():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: '\.hidden.md'
-    - p: 'README\.md'
+    - require: '\.hidden.md'
+    - require: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -676,7 +667,7 @@ def test_succeed_gitignored_file():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
+    - require: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -696,7 +687,7 @@ def test_fail_unspecified_link():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
+    - require: 'README\.md'
 directory_map:
   /:
     - use_rule: base_structure
@@ -719,8 +710,8 @@ def test_succeed_specified_link():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
-    - p: 'link'
+    - require: 'README\.md'
+    - require: 'link'
 directory_map:
   /:
     - use_rule: base_structure
@@ -748,12 +739,12 @@ def test_succeed_template_rule():
     config_yaml = r"""
 templates:
   component:
-    - p: '{{component}}/'
+    - require: '{{component}}/'
       if_exists:
-      - p: '{{component}}_component.py'
-      - p: 'doc/'
+      - require: '{{component}}_component.py'
+      - require: 'doc/'
         if_exists:
-        - p: '{{component}}.techspec.md'
+        - require: '{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -780,12 +771,12 @@ def test_fail_template_rule_missing_file():
     config_yaml = r"""
 templates:
   component:
-    - p: '{{component}}/'
+    - require: '{{component}}/'
       if_exists:
-      - p: '{{component}}_component.py'
-      - p: 'doc/'
+      - require: '{{component}}_component.py'
+      - require: 'doc/'
         if_exists:
-        - p: '{{component}}.techspec.md'
+        - require: '{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -813,13 +804,12 @@ def test_succeed_template_rule_if_exists():
     config_yaml = r"""
 templates:
   component:
-    - p: '{{component}}/'
+    - require: '{{component}}/'
       if_exists:
-      - p: '{{component}}_component.py'
-      - p: 'doc/'
-        required: False
+      - require: '{{component}}_component.py'
+      - allow: 'doc/'
         if_exists:
-          - p: '{{component}}.techspec.md'
+          - require: '{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -855,12 +845,12 @@ def test_succeed_template_rule_subdirectory_map():
     config_yaml = r"""
 templates:
   component:
-    - p: '{{component}}/'
+    - require: '{{component}}/'
       if_exists:
-      - p: '{{component}}_component.py'
-      - p: 'doc/'
+      - require: '{{component}}_component.py'
+      - require: 'doc/'
         if_exists:
-        - p: '{{component}}.techspec.md'
+        - require: '{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -899,12 +889,12 @@ def test_fail_template_rule_subdirectory_map_missing_file():
     config_yaml = r"""
 templates:
   component:
-    - p: '{{component}}/'
+    - require: '{{component}}/'
       if_exists:
-      - p: '{{component}}_component.py'
-      - p: 'doc/'
+      - require: '{{component}}_component.py'
+      - require: 'doc/'
         if_exists:
-        - p: '{{component}}.techspec.md'
+        - require: '{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -945,12 +935,12 @@ def test_succeed_template_rule_multiple_expansions():
     config_yaml = r"""
 templates:
   example_template:
-    - p: '{{component}}/'
+    - require: '{{component}}/'
       if_exists:
-      - p: '{{component}}_component.{{extension}}'
-      - p: 'doc/'
+      - require: '{{component}}_component.{{extension}}'
+      - require: 'doc/'
         if_exists:
-        - p: '{{component}}.techspec.md'
+        - require: '{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: example_template
@@ -984,19 +974,17 @@ def test_succeed_with_verbose():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
-    - p: 'doc/'
-      required: False
+    - require: 'README\.md'
+    - allow: 'doc/'
       use_rule: base_structure
 templates:
   component:
-    - p: '{{component}}/'
+    - require: '{{component}}/'
       if_exists:
-      - p: '{{component}}_component.py'
-      - p: 'doc/'
-        required: False
+      - require: '{{component}}_component.py'
+      - allow: 'doc/'
         if_exists:
-          - p: '{{component}}.techspec.md'
+          - require: '{{component}}.techspec.md'
 directory_map:
   /:
     - use_template: component
@@ -1023,11 +1011,11 @@ def test_forbid_file():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - p: 'README\.md'
+    - require: 'README\.md'
     - forbid: 'CMakeLists\.txt'
-    - p: 'python/'
+    - require: 'python/'
       if_exists:
-      - p: '.*\.py'
+      - require: '.*\.py'
 directory_map:
   /:
     - use_rule: base_structure

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -27,6 +27,10 @@ class ConfigurationParseError(Exception):
     """Thrown when configuration could not be parsed."""
 
 
+class ForbiddenEntryError(Exception):
+    """Thrown when a forbidden entry is found."""
+
+
 @dataclass
 class RepoEntry:
     """Wrapper for entries in the directory structure, that store the path
@@ -147,6 +151,8 @@ def _get_matching_item_index(
         if v.path.fullmatch(entry_path) and v.is_dir == is_dir:
             if verbose:
                 print(f"  Found match at index {i}: {v.path.pattern}")
+            if v.is_forbidden:
+                raise ForbiddenEntryError(f"Found forbidden entry: {entry_path}")
             result.append(i)
     if len(result) != 0:
         return result


### PR DESCRIPTION
Forbid files - will have precedence over allowed and optional files. No check for collisions.