### PR TITLE
Add and handle 'ignore' rule for directory mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,12 +244,29 @@ structure_rules:
       # allow library recursion
       use_rule: python_library
 directory_map:
-"/":
+/:
   - use_rule: basic_rule
-"/python/":
+/python/:
   - use_rule: python_main
   - use_rule: python_library
 ```
+
+Ignoring a directory can be done using the built-in rule `ignore`. For example:
+
+```yaml
+tructure_rules:
+  basic_rule:
+    - require: "LICENSE"
+    - require: "BUILD"
+  python_main:
+directory_map:
+/:
+  - use_rule: basic_rule
+/python/:
+  - use_rule: ignore
+```
+
+The rule can
 
 ## System Requirements
 

--- a/repo_structure.yaml
+++ b/repo_structure.yaml
@@ -20,6 +20,14 @@ structure_rules:
     - p: "repo_struct/"
       if_exists:
         - p: "README.md"
+  ignore:
+    - p: ".*"
+      required: False
+    - p: ".*/"
+      required: False
+      if_exists:
+        - p: ".*"
+          required: False
 
 directory_map:
   /:

--- a/repo_structure.yaml
+++ b/repo_structure.yaml
@@ -1,11 +1,5 @@
 structure_rules:
   base_structure:
-    - p: ".github/"
-      if_exists:
-        - p: 'dependabot\.yml'
-        - p: "workflows/"
-          if_exists:
-            - p: '.*\.y(a)?ml'
     - p: "environment.yml"
     - p: "requirements.txt"
     - p: "LICENSE"
@@ -33,3 +27,5 @@ directory_map:
     - use_rule: test_dir
   /repo_structure/:
     - use_rule: python_package
+  /.github/:
+    - use_rule: ignore

--- a/repo_structure/__main__.py
+++ b/repo_structure/__main__.py
@@ -142,7 +142,7 @@ def full_scan(ctx: click.Context, repo_root: str, config_path: str) -> None:
 @click.argument(
     "paths",
     nargs=-1,
-    type=click.Path(exists=True),
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
     required=False,
 )
 @click.pass_context

--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -19,6 +19,7 @@ from .repo_structure_lib import (
     DirectoryMap,
     StructureRuleList,
     StructureRuleMap,
+    BUILTIN_DIRECTORY_RULES,
 )
 from .repo_structure_schema import get_json_schema
 
@@ -117,7 +118,7 @@ class Configuration:
         existing_rules = self.config.structure_rules.keys()
         for directory, rule in self.config.directory_map.items():
             for r in rule:
-                if r not in existing_rules:
+                if r not in existing_rules and r not in BUILTIN_DIRECTORY_RULES:
                     raise UseRuleError(
                         f"Directory mapping '{directory}' uses non-existing rule '{r}'"
                     )

--- a/repo_structure/repo_structure_config_test.py
+++ b/repo_structure/repo_structure_config_test.py
@@ -52,6 +52,8 @@ directory_map:
     - use_template: software_component
       parameters:
         component_name: ['lidar', 'camera', 'driver', 'control']
+  /repo_struct/:
+    - use_rule: ignore
     """
     # parsing should not throw using the above yaml
     config = Configuration(test_yaml, True)

--- a/repo_structure/repo_structure_diff_scan.py
+++ b/repo_structure/repo_structure_diff_scan.py
@@ -107,6 +107,10 @@ def assert_path(
     backlog = _map_dir_to_entry_backlog(
         config.directory_map, config.structure_rules, map_dir_to_rel_dir(map_dir)
     )
+    if not backlog:
+        if flags.verbose:
+            print("backlog empty - returning success")
+        return
 
     rel_path = os.path.relpath(path, map_dir_to_rel_dir(map_dir))
     try:

--- a/repo_structure/repo_structure_diff_scan_test.py
+++ b/repo_structure/repo_structure_diff_scan_test.py
@@ -155,3 +155,22 @@ def test_skip_file():
     config_filname = "repo_structure.yaml"
     config = Configuration(config_filname)
     assert_path(config, "repo_structure.yaml")
+
+
+def test_ignore_rule():
+    """Test with ignored directory."""
+    config_yaml = r"""
+structure_rules:
+  base_structure:
+    - require: 'README\.md'
+directory_map:
+  /:
+    - use_rule: base_structure
+  /python/:
+    - use_rule: ignore
+        """
+    config = Configuration(config_yaml, True)
+    flags = Flags()
+    flags.verbose = True
+    assert_path(config, "README.md", flags)
+    assert_path(config, "python/main.py", flags)

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -4,7 +4,7 @@
 
 import os
 
-from typing import List, Callable, Optional, Union
+from typing import List, Callable, Union
 from gitignore_parser import parse_gitignore
 
 from .repo_structure_lib import Flags, UnspecifiedEntryError, ForbiddenEntryError
@@ -142,7 +142,7 @@ def _fail_if_invalid_repo_structure_recursive(
 
 
 def _process_map_dir(
-    map_dir: str, repo_root: str, config: Configuration, flags: Optional[Flags]
+    map_dir: str, repo_root: str, config: Configuration, flags: Flags = Flags()
 ):
     """Process a single map directory entry."""
     rel_dir = map_dir_to_rel_dir(map_dir)
@@ -151,7 +151,7 @@ def _process_map_dir(
     )
 
     if not backlog:
-        if flags and flags.verbose:
+        if flags.verbose:
             print("backlog empty - returning success")
         return
 
@@ -160,7 +160,7 @@ def _process_map_dir(
         rel_dir,
         config,
         backlog,
-        flags or Flags(),
+        flags,
     )
     _fail_if_required_entries_missing(backlog)
 

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -150,6 +150,11 @@ def _process_map_dir(
         config.directory_map, config.structure_rules, rel_dir
     )
 
+    if not backlog:
+        if flags and flags.verbose:
+            print("backlog empty - returning success")
+        return
+
     _fail_if_invalid_repo_structure_recursive(
         repo_root,
         rel_dir,

--- a/repo_structure/repo_structure_full_scan_test.py
+++ b/repo_structure/repo_structure_full_scan_test.py
@@ -1023,3 +1023,27 @@ directory_map:
     config = Configuration(config_yaml, True)
     with pytest.raises(ForbiddenEntryError):
         _assert_repo_directory_structure(config)
+
+
+@with_repo_structure_in_tmpdir(
+    """
+README.md
+python/
+python/whatever.py
+python/this_is_ignored.py
+"""
+)
+def test_ignore_rule():
+    """Test with ignored directory."""
+    config_yaml = r"""
+structure_rules:
+  base_structure:
+    - require: 'README\.md'
+directory_map:
+  /:
+    - use_rule: base_structure
+  /python/:
+    - use_rule: ignore
+        """
+    config = Configuration(config_yaml, True)
+    _assert_repo_directory_structure(config)

--- a/repo_structure/repo_structure_full_scan_test.py
+++ b/repo_structure/repo_structure_full_scan_test.py
@@ -985,6 +985,7 @@ templates:
       - allow: 'doc/'
         if_exists:
           - require: '{{component}}.techspec.md'
+          - forbid: 'CMakeLists\.txt'
 directory_map:
   /:
     - use_template: component
@@ -1045,5 +1046,7 @@ directory_map:
   /python/:
     - use_rule: ignore
         """
+    flags = Flags()
+    flags.verbose = True
     config = Configuration(config_yaml, True)
-    _assert_repo_directory_structure(config)
+    _assert_repo_directory_structure(config, flags)

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -4,7 +4,9 @@ import os
 import re
 from dataclasses import dataclass, field, replace
 from os import DirEntry
-from typing import List, Union, Callable, Dict
+from typing import List, Union, Callable, Dict, Final
+
+BUILTIN_DIRECTORY_RULES: Final = ["ignore"]
 
 
 class UnspecifiedEntryError(Exception):
@@ -211,6 +213,8 @@ def _build_active_entry_backlog(
 ) -> StructureRuleList:
     result: StructureRuleList = []
     for rule in active_use_rules:
+        if rule == "ignore":
+            continue
         for e in structure_rules[rule]:
             result.append(replace(e, path=re.compile(e.path.pattern)))
     return result


### PR DESCRIPTION
Making it much faster to run over ignored directories in contrast to allowing all entries