### PR TITLE
Enhance rule validation in repo structure scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ Keep this rule in the back of your head when designing the structure rules. You
 won't get noticed if you make a mistake, unless you run into a directory
 structure that happens to run into the issue.
 
+For example, the following configuration would fail always
+
+```yaml
+structure_rules:
+  example_rule:
+    - require: ".*"
+    - require: 'main\.py'
+```
+
 ## Templates
 
 Templates provide the ability to reuse patterns of directory structures and

--- a/README.md
+++ b/README.md
@@ -155,6 +155,18 @@ structure_rules:
       use_rule: example_rule_with_recursion
 ```
 
+## Pattern Matching Order
+
+Patterns are matched in the order they are declared. Once a rule is matched,
+the processing is stopped. Hence, wildcard patterns must be put to the end of
+the structure rules. Or more precise:
+
+> Less specific patterns need to come later that more specific patterns.
+
+Keep this rule in the back of your head when designing the structure rules. You
+won't get noticed if you make a mistake, unless you run into a directory
+structure that happens to run into the issue.
+
 ## Templates
 
 Templates provide the ability to reuse patterns of directory structures and

--- a/repo_structure/repo_structure_diff_scan.py
+++ b/repo_structure/repo_structure_diff_scan.py
@@ -60,25 +60,25 @@ def _assert_path_in_backlog(
         ):
             return
 
-        for idx in _get_matching_item_index(
+        idx = _get_matching_item_index(
             backlog,
             entry_name,
             is_dir,
             flags.verbose,
-        ):
-            if flags.verbose:
-                print(f"  Found match for path {entry_name}")
+        )
+        if flags.verbose:
+            print(f"  Found match for path {entry_name}")
 
-            if is_dir:
-                backlog_match = backlog[idx]
-                backlog = _handle_use_rule(
-                    backlog_match.use_rule,
-                    config.structure_rules,
-                    flags,
-                    entry_name,
-                )
-                if not backlog:
-                    backlog = _handle_if_exists(backlog_match, flags)
+        if is_dir:
+            backlog_match = backlog[idx]
+            backlog = _handle_use_rule(
+                backlog_match.use_rule,
+                config.structure_rules,
+                flags,
+                entry_name,
+            )
+            if not backlog:
+                backlog = _handle_if_exists(backlog_match, flags)
 
 
 def assert_path(

--- a/repo_structure/repo_structure_diff_scan.py
+++ b/repo_structure/repo_structure_diff_scan.py
@@ -70,14 +70,15 @@ def _assert_path_in_backlog(
                 print(f"  Found match for path {entry_name}")
 
             if is_dir:
-                _handle_use_rule(
-                    backlog,
-                    backlog[idx].use_rule,
+                backlog_match = backlog[idx]
+                backlog = _handle_use_rule(
+                    backlog_match.use_rule,
                     config.structure_rules,
                     flags,
                     entry_name,
                 )
-                _handle_if_exists(backlog, backlog[idx], flags)
+                if not backlog:
+                    backlog = _handle_if_exists(backlog_match, flags)
 
 
 def assert_path(

--- a/repo_structure/repo_structure_diff_scan.py
+++ b/repo_structure/repo_structure_diff_scan.py
@@ -72,13 +72,8 @@ def _assert_path_in_backlog(
         if is_dir:
             backlog_match = backlog[idx]
             backlog = _handle_use_rule(
-                backlog_match.use_rule,
-                config.structure_rules,
-                flags,
-                entry_name,
-            )
-            if not backlog:
-                backlog = _handle_if_exists(backlog_match, flags)
+                backlog_match.use_rule, config.structure_rules, flags, entry_name
+            ) or _handle_if_exists(backlog_match, flags)
 
 
 def assert_path(

--- a/repo_structure/repo_structure_diff_scan_test.py
+++ b/repo_structure/repo_structure_diff_scan_test.py
@@ -49,6 +49,24 @@ directory_map:
         assert_path(config, "python/bad_filename.py")
 
 
+def test_matching_regex_dir_if_exists():
+    """Test with required file."""
+    config_yaml = r"""
+structure_rules:
+  recursive_rule:
+    - require: 'main\.py'
+    - require: 'python/'
+      if_exists:
+        - require: '.*'
+directory_map:
+  /:
+    - use_rule: recursive_rule
+    """
+    config = Configuration(config_yaml, True)
+    assert_path(config, "main.py")
+    assert_path(config, "python/something.py")
+
+
 def test_multi_use_rule():
     """Test multiple use rules."""
     config_yaml = r"""

--- a/repo_structure/repo_structure_diff_scan_test.py
+++ b/repo_structure/repo_structure_diff_scan_test.py
@@ -11,32 +11,22 @@ from .repo_structure_diff_scan import assert_path
 
 
 def test_matching_regex():
-    """Test with required file."""
+    """Test with required, forbidden, and allowed file."""
     config_yaml = r"""
 structure_rules:
   base_structure:
     - require: 'README\.md'
+    - forbid: 'CMakeLists\.txt'
+    - allow: 'LICENSE'
 directory_map:
   /:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
     assert_path(config, "README.md")
+    assert_path(config, "LICENSE")
     with pytest.raises(UnspecifiedEntryError):
         assert_path(config, "bad_filename.md")
-
-
-def test_forbidden_entry():
-    """Test with forbidden file."""
-    config_yaml = r"""
-structure_rules:
-  base_structure:
-    - forbid: 'CMakeLists\.txt'
-directory_map:
-  /:
-    - use_rule: base_structure
-    """
-    config = Configuration(config_yaml, True)
     with pytest.raises(ForbiddenEntryError):
         assert_path(config, "CMakeLists.txt")
 
@@ -75,25 +65,8 @@ directory_map:
     config = Configuration(config_yaml, True)
     assert_path(config, "README.md")
     assert_path(config, "main.py")
-
-
-def test_multi_use_rule_fail():
-    """Test multi use rule diff scan fail."""
-    config_yaml = r"""
-structure_rules:
-  base_structure:
-      - require: 'README\.md'
-  python_package:
-      - require: '.*\.py'
-directory_map:
-  /:
-    - use_rule: base_structure
-    - use_rule: python_package
-    """
-    config = Configuration(config_yaml, True)
-    assert_path(config, "README.md")
     with pytest.raises(UnspecifiedEntryError):
-        assert_path(config, "main.cpp")  # bad file name
+        assert_path(config, "bad_file_name.cpp")
 
 
 def test_use_rule_recursive():
@@ -115,8 +88,11 @@ directory_map:
     flags.verbose = True
     config = Configuration(config_yaml, True)
     assert_path(config, "main/main.cpp", flags)
+    assert_path(config, "main/main/main.cpp", flags)
     with pytest.raises(UnspecifiedEntryError):
         assert_path(config, "main/main.rs", flags)
+    with pytest.raises(UnspecifiedEntryError):
+        assert_path(config, "main/main/main.rs", flags)
 
 
 def test_succeed_elaborate_use_rule_recursive():

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -124,15 +124,14 @@ def _fail_if_invalid_repo_structure_recursive(
             backlog_entry.count += 1
 
             if os_entry.is_dir():
-                new_backlog: StructureRuleList = []
-                _handle_use_rule(
-                    new_backlog,
+                new_backlog = _handle_use_rule(
                     backlog_entry.use_rule,
                     config.structure_rules,
                     flags,
                     entry.path,
                 )
-                _handle_if_exists(new_backlog, backlog_entry, flags)
+                if not new_backlog:
+                    new_backlog = _handle_if_exists(backlog_entry, flags)
 
                 _fail_if_invalid_repo_structure_recursive(
                     repo_root,

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -119,18 +119,16 @@ def _fail_if_invalid_repo_structure_recursive(
                 f"Forbidden entry found: '{entry.rel_dir}/{entry.path}'"
             ) from err
 
-        backlog_entry = backlog[idx]
-        backlog_entry.count += 1
+        backlog_match = backlog[idx]
+        backlog_match.count += 1
 
         if os_entry.is_dir():
             new_backlog = _handle_use_rule(
-                backlog_entry.use_rule,
+                backlog_match.use_rule,
                 config.structure_rules,
                 flags,
                 entry.path,
-            )
-            if not new_backlog:
-                new_backlog = _handle_if_exists(backlog_entry, flags)
+            ) or _handle_if_exists(backlog_match, flags)
 
             _fail_if_invalid_repo_structure_recursive(
                 repo_root,

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -104,7 +104,7 @@ def _fail_if_invalid_repo_structure_recursive(
             continue
 
         try:
-            indices = _get_matching_item_index(
+            idx = _get_matching_item_index(
                 backlog,
                 entry.path,
                 os_entry.is_dir(),
@@ -119,30 +119,29 @@ def _fail_if_invalid_repo_structure_recursive(
                 f"Forbidden entry found: '{entry.rel_dir}/{entry.path}'"
             ) from err
 
-        for idx in indices:
-            backlog_entry = backlog[idx]
-            backlog_entry.count += 1
+        backlog_entry = backlog[idx]
+        backlog_entry.count += 1
 
-            if os_entry.is_dir():
-                new_backlog = _handle_use_rule(
-                    backlog_entry.use_rule,
-                    config.structure_rules,
-                    flags,
-                    entry.path,
-                )
-                if not new_backlog:
-                    new_backlog = _handle_if_exists(backlog_entry, flags)
+        if os_entry.is_dir():
+            new_backlog = _handle_use_rule(
+                backlog_entry.use_rule,
+                config.structure_rules,
+                flags,
+                entry.path,
+            )
+            if not new_backlog:
+                new_backlog = _handle_if_exists(backlog_entry, flags)
 
-                _fail_if_invalid_repo_structure_recursive(
-                    repo_root,
-                    os.path.join(rel_dir, entry.path),
-                    config,
-                    new_backlog,
-                    flags,
-                )
-                _fail_if_required_entries_missing(
-                    os.path.join(rel_dir, entry.path), new_backlog
-                )
+            _fail_if_invalid_repo_structure_recursive(
+                repo_root,
+                os.path.join(rel_dir, entry.path),
+                config,
+                new_backlog,
+                flags,
+            )
+            _fail_if_required_entries_missing(
+                os.path.join(rel_dir, entry.path), new_backlog
+            )
 
 
 def _process_map_dir(

--- a/repo_structure/repo_structure_full_scan_test.py
+++ b/repo_structure/repo_structure_full_scan_test.py
@@ -19,7 +19,7 @@ from .repo_structure_lib import (
     Flags,
     UnspecifiedEntryError,
     ConfigurationParseError,
-    ForbiddenEntryError,
+    ForbiddenEntryError, OverlappingRuleError,
 )
 
 
@@ -131,7 +131,6 @@ directory_map:
 
 @with_repo_structure_in_tmpdir(
     """
-README.md
 python/
 python/main.py
 """
@@ -141,10 +140,9 @@ def test_required_dir():
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - require: 'README\.md'
     - require: 'python/'
       if_exists:
-      - require: '.*\.py'
+      - allow: '.*\.py'
 directory_map:
   /:
     - use_rule: base_structure
@@ -240,6 +238,28 @@ directory_map:
         """
     config = Configuration(config_yaml, True)
     with pytest.raises(MissingRequiredEntriesError):
+        _assert_repo_directory_structure(config)
+
+@with_repo_structure_in_tmpdir(
+    """
+README.md
+"""
+)
+def test_fail_rule_precedence():
+    """Test rule precedence. This needs to fail because the wildcard consumes all matches.
+
+    The first match wins and that needs to be kept in mind when designing the rules."""
+    config_yaml = r"""
+structure_rules:
+  base_structure:
+    - require: '.*'
+    - require: 'README\.md'
+directory_map:
+  /:
+    - use_rule: base_structure
+"""
+    config = Configuration(config_yaml, True)
+    with pytest.raises(OverlappingRuleError):
         _assert_repo_directory_structure(config)
 
 
@@ -372,26 +392,6 @@ directory_map:
     config = Configuration(config_yaml, True)
     with pytest.raises(UnspecifiedEntryError):
         _assert_repo_directory_structure(config)
-
-
-@with_repo_structure_in_tmpdir(
-    """
-README.md
-"""
-)
-def test_succeed_overlapping_required_file_rules():
-    """Test for overlapping required file rules - two different rules apply to the same file."""
-    config_yaml = r"""
-structure_rules:
-  base_structure:
-    - require: 'README\.md'
-    - require: 'README\..*'
-directory_map:
-  /:
-    - use_rule: base_structure
-    """
-    config = Configuration(config_yaml, True)
-    _assert_repo_directory_structure(config)
 
 
 @with_repo_structure_in_tmpdir(

--- a/repo_structure/repo_structure_full_scan_test.py
+++ b/repo_structure/repo_structure_full_scan_test.py
@@ -20,7 +20,6 @@ from .repo_structure_lib import (
     UnspecifiedEntryError,
     ConfigurationParseError,
     ForbiddenEntryError,
-    OverlappingRuleError,
 )
 
 
@@ -250,7 +249,7 @@ README.md
 def test_fail_rule_precedence():
     """Test rule precedence. This needs to fail because the wildcard consumes all matches.
 
-    The first match wins and that needs to be kept in mind when designing the rules."""
+    The first match wins and thus the README.md will never be reached."""
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -261,7 +260,7 @@ directory_map:
     - use_rule: base_structure
 """
     config = Configuration(config_yaml, True)
-    with pytest.raises(OverlappingRuleError):
+    with pytest.raises(MissingRequiredEntriesError):
         _assert_repo_directory_structure(config)
 
 

--- a/repo_structure/repo_structure_full_scan_test.py
+++ b/repo_structure/repo_structure_full_scan_test.py
@@ -19,7 +19,8 @@ from .repo_structure_lib import (
     Flags,
     UnspecifiedEntryError,
     ConfigurationParseError,
-    ForbiddenEntryError, OverlappingRuleError,
+    ForbiddenEntryError,
+    OverlappingRuleError,
 )
 
 
@@ -239,6 +240,7 @@ directory_map:
     config = Configuration(config_yaml, True)
     with pytest.raises(MissingRequiredEntriesError):
         _assert_repo_directory_structure(config)
+
 
 @with_repo_structure_in_tmpdir(
     """

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -33,10 +33,6 @@ class ForbiddenEntryError(Exception):
     """Thrown when a forbidden entry is found."""
 
 
-class OverlappingRuleError(Exception):
-    """Thrown when a overlapping rule is found."""
-
-
 @dataclass
 class RepoEntry:
     """Wrapper for entries in the directory structure, that store the path
@@ -151,24 +147,14 @@ def _get_matching_item_index(
     entry_path: str,
     is_dir: bool,
     verbose: bool = False,
-) -> List[int]:
-    result: List[int] = []
+) -> int:
     for i, v in enumerate(backlog):
         if v.path.fullmatch(entry_path) and v.is_dir == is_dir:
-            if verbose:
-                print(f"  Found match at index {i}: {v.path.pattern}")
             if v.is_forbidden:
                 raise ForbiddenEntryError(f"Found forbidden entry: {entry_path}")
-            result.append(i)
-            if len(result) > 1:
-                overlapping_rule_paths = "\n".join(
-                    [backlog[x].path.pattern for x in result]
-                )
-                raise OverlappingRuleError(
-                    f"Found overlapping rules for: {entry_path}.\n{overlapping_rule_paths}"
-                )
-    if len(result) != 0:
-        return result
+            if verbose:
+                print(f"  Found match at index {i}: {v.path.pattern}")
+            return i
 
     if is_dir:
         entry_path += "/"

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -32,6 +32,7 @@ class ConfigurationParseError(Exception):
 class ForbiddenEntryError(Exception):
     """Thrown when a forbidden entry is found."""
 
+
 class OverlappingRuleError(Exception):
     """Thrown when a overlapping rule is found."""
 
@@ -160,8 +161,12 @@ def _get_matching_item_index(
                 raise ForbiddenEntryError(f"Found forbidden entry: {entry_path}")
             result.append(i)
             if len(result) > 1:
-                overlapping_rule_paths = "\n".join([backlog[x].path.pattern for x in result])
-                raise OverlappingRuleError(f"Found overlapping rules for: {entry_path}.\n{overlapping_rule_paths}")
+                overlapping_rule_paths = "\n".join(
+                    [backlog[x].path.pattern for x in result]
+                )
+                raise OverlappingRuleError(
+                    f"Found overlapping rules for: {entry_path}.\n{overlapping_rule_paths}"
+                )
     if len(result) != 0:
         return result
 
@@ -180,14 +185,13 @@ def _handle_use_rule(
         if flags.verbose:
             print(f"use_rule found for rel path {rel_path}")
         return _build_active_entry_backlog(
-                [use_rule],
-                structure_rules,
-            )
+            [use_rule],
+            structure_rules,
+        )
+    return None
 
 
-def _handle_if_exists(
-    backlog_entry: RepoEntry, flags: Flags
-):
+def _handle_if_exists(backlog_entry: RepoEntry, flags: Flags):
     if backlog_entry.if_exists:
         if flags.verbose:
             print(f"if_exists found for rel path {backlog_entry.path.pattern}")

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -183,8 +183,7 @@ def _handle_if_exists(backlog_entry: RepoEntry, flags: Flags):
             print(f"if_exists found for rel path {backlog_entry.path.pattern}")
         return backlog_entry.if_exists
     # the following line can not be reached given the current integration
-    # pragma: no cover
-    return None
+    return None  # pragma: no cover
 
 
 def _map_dir_to_entry_backlog(

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -196,6 +196,7 @@ def _handle_if_exists(backlog_entry: RepoEntry, flags: Flags):
         if flags.verbose:
             print(f"if_exists found for rel path {backlog_entry.path.pattern}")
         return backlog_entry.if_exists
+    return None
 
 
 def _map_dir_to_entry_backlog(

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -182,6 +182,8 @@ def _handle_if_exists(backlog_entry: RepoEntry, flags: Flags):
         if flags.verbose:
             print(f"if_exists found for rel path {backlog_entry.path.pattern}")
         return backlog_entry.if_exists
+    # the following line can not be reached given the current integration
+    # pragma: no cover
     return None
 
 

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -2,7 +2,7 @@
 
 import os
 import re
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from os import DirEntry
 from typing import List, Union, Callable, Dict, Final
 
@@ -217,6 +217,5 @@ def _build_active_entry_backlog(
     for rule in active_use_rules:
         if rule == "ignore":
             continue
-        for e in structure_rules[rule]:
-            result.append(replace(e, path=re.compile(e.path.pattern))) # TODO: do we need the "replace" here?
+        result += structure_rules[rule]
     return result


### PR DESCRIPTION
rule matching used to allow multiple matching rules and made sure they were checked. Now we assume rules to be processed in order and if a rule is overlapping, only the first match will be registered and an error is raised in case other rules match (that might go away, though)