### PR TITLE
Remove redundant validation for `use_rule`

### DIFF
--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -161,18 +161,8 @@ def _parse_structure_rules(structure_rules_yaml: dict) -> StructureRuleMap:
                         "is not a valid rule key"
                     )
 
-    def _validate_use_rule_only_recursive(rules: StructureRuleMap) -> None:
-        for rule_key in rules.keys():
-            for entry in rules[rule_key]:
-                if entry.use_rule and entry.use_rule != rule_key:
-                    raise UseRuleError(
-                        f"use_rule '{entry.use_rule}' in entry '{entry.path.pattern}'"
-                        "is not recursive"
-                    )
-
     rules = _build_rules(structure_rules_yaml)
     _validate_use_rule_not_dangling(rules)
-    _validate_use_rule_only_recursive(rules)
 
     return rules
 

--- a/repo_structure/repo_structure_config_test.py
+++ b/repo_structure/repo_structure_config_test.py
@@ -217,22 +217,20 @@ directory_map:
         Configuration(test_config, True)
 
 
-def test_fail_use_rule_not_recursive():
-    """Test use rule usage not recursive."""
+def test_use_rule_mixin():
+    """Test use rule usage not recursive - mix in another rule."""
     config_yaml = r"""
 structure_rules:
     license_rule:
         - require: 'LICENSE'
-    bad_use_rule:
+    other_rule:
         - allow: '.*/'
           use_rule: license_rule
 directory_map:
   /:
-    # it doesn't matter here what we 'use', the test should fail always
-    - use_rule: bad_use_rule
+    - use_rule: other_rule
     """
-    with pytest.raises(UseRuleError):
-        Configuration(config_yaml, True)
+    Configuration(config_yaml, True)
 
 
 def test_fail_directory_map_missing_trailing_slash():


### PR DESCRIPTION
It has turned out to be a too strict rule and it caused a lot of duplication to have use_rule only allow recursive rules and not mixin kind of declarations.