### PR TITLE
Update pre-commit hook IDs for better clarity and consistency**

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,4 @@
-- id: full
+- id: repo-structure-full
   name: Enforce Repository Structure
   entry: repo_structure full-scan --repo-root .
   description: Ensuring the repository structure contains all entries, including `required`, from the configuration
@@ -6,7 +6,7 @@
   pass_filenames: false
   args: ["--config-path", "repo_structure.yaml"]
   stages: [manual]
-- id: full-debug
+- id: repo-structure-full-debug
   name: Enforce Repository Structure
   entry: repo_structure --verbose full-scan --repo-root .
   description: Ensuring the repository structure contains all entries, including `required`, from the configuration - with debug tracing
@@ -14,17 +14,15 @@
   pass_filenames: false
   args: ["--config-path", "repo_structure.yaml"]
   stages: [manual]
-- id: diff
+- id: repo-structure-diff
   name: Enforce Repository Structure
   entry: repo_structure diff-scan
   description: Ensuring the repository structure does not contain files that are not listed in the configuration file
   language: python
-  pass_filenames: false
   args: ["--config-path", "repo_structure.yaml"]
-- id: diff-debug
+- id: repo-structure-diff-debug
   name: Enforce Repository Structure
   entry: repo_structure --verbose diff-scan
   description: Ensuring the repository structure does not contain files that are not listed in the configuration file - with debug tracing
   language: python
-  pass_filenames: false
   args: ["--config-path", "repo_structure.yaml"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A basic consumption with pre-commit looks like the following.
 ```yaml
 repos:
   - repo: https://github.com/nesono/repo_structure
-    rev: "v0.5.0"
+    rev: ""
     hooks:
       - id: repo-structure-diff-scan
 ```
@@ -53,7 +53,7 @@ to the yaml, for instance:
 ```yaml
 repos:
   - repo: https://github.com/nesono/repo_structure
-    rev: "v0.5.0"
+    rev: ""
     hooks:
       - id: repo-structure-diff-scan
         args: ["--config-path", "path/to/your_config_file.yaml"]
@@ -63,12 +63,12 @@ repos:
 
 The following modes are available with Repo Structure:
 
-| ID           | Description                                                                                                  |
-| ------------ | ------------------------------------------------------------------------------------------------------------ |
-| `diff`       | Ensure that all added or modified files are allowed by the repo structure configuration                      |
-| `diff-debug` | Ensure that all added or modified files are allowed by the repo structure configuration with tracing enabled |
-| `full`       | Run a full scan ensuring that all allowed and required files exist                                           |
-| `full-debug` | Run a full scan ensuring that all allowed and required files exist with tracing enabled                      |
+| ID                          | Description                                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `repo-structure-diff`       | Ensure that all added or modified files are allowed by the repo structure configuration                      |
+| `repo-structure-diff-debug` | Ensure that all added or modified files are allowed by the repo structure configuration with tracing enabled |
+| `repo-structure-full`       | Run a full scan ensuring that all allowed and required files exist                                           |
+| `repo-structure-full-debug` | Run a full scan ensuring that all allowed and required files exist with tracing enabled                      |
 
 Note that the full scan hooks might take longer time than you are willing to spend during `pre-commit`.
 You can enable then for the `pre-push` stage only, or you can run the tool in the terminal installed from pip.


### PR DESCRIPTION
Updated hook identifiers in `.pre-commit-hooks.yaml` to use more descriptive prefixes (`repo-structure-*`), enhancing clarity and ensuring consistent differentiation of hooks. This improves ease of maintenance and identification in repository workflows