### PR TITLE
Add _process_map_dir_with_return_values function as non-throwing alternative

### DIFF
--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -159,7 +159,7 @@ def _fail_if_invalid_repo_structure_recursive(
             )
 
 
-def _process_map_dir(
+def _process_map_dir_except(
     map_dir: str, repo_root: str, config: Configuration, flags: Flags = Flags()
 ):
     """Process a single map directory entry."""
@@ -195,13 +195,13 @@ def assert_full_repository_structure(
         raise MissingMappingError("Config does not have a root mapping")
 
     for map_dir in config.directory_map:
-        _process_map_dir(map_dir, repo_root, config, flags)
+        _process_map_dir_except(map_dir, repo_root, config, flags)
 
 
 # pylint: disable=too-many-branches, too-many-nested-blocks
 
 
-def _process_map_dir_with_return_values(
+def _process_map_dir_sync(
     map_dir: str, repo_root: str, config: Configuration, flags: Flags = Flags()
 ) -> List[ScanIssue]:
     """Process a single map directory entry and return issues instead of raising exceptions."""
@@ -297,9 +297,7 @@ def scan_full_repository(
     else:
         # Process each mapped directory independently, collecting errors
         for map_dir in config.directory_map:
-            map_dir_errors = _process_map_dir_with_return_values(
-                map_dir, repo_root, config, flags
-            )
+            map_dir_errors = _process_map_dir_sync(map_dir, repo_root, config, flags)
             errors.extend(map_dir_errors)
 
     warnings: List[ScanIssue] = []

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -304,32 +304,29 @@ def scan_full_repository(
 
     warnings: List[ScanIssue] = []
     # Compute unused rule warnings (do not throw)
-    try:
-        used_rules = set()
-        for rules in config.directory_map.values():
-            for r in rules:
-                if r and r not in ("ignore",):
-                    used_rules.add(r)
-        changed = True
-        while changed:
-            changed = False
-            for rule_name in list(used_rules):
-                for entry in config.structure_rules.get(rule_name, []):
-                    if entry.use_rule and entry.use_rule not in ("ignore",):
-                        if entry.use_rule not in used_rules:
-                            used_rules.add(entry.use_rule)
-                            changed = True
-        for rule_name in config.structure_rules.keys():
-            if rule_name not in used_rules:
-                warnings.append(
-                    ScanIssue(
-                        severity="warning",
-                        code="unused_structure_rule",
-                        message=f"Unused structure rule '{rule_name}'",
-                        path=None,
-                    )
+    used_rules = set()
+    for rules in config.directory_map.values():
+        for r in rules:
+            if r and r not in ("ignore",):
+                used_rules.add(r)
+    changed = True
+    while changed:
+        changed = False
+        for rule_name in list(used_rules):
+            for entry in config.structure_rules.get(rule_name, []):
+                if entry.use_rule and entry.use_rule not in ("ignore",):
+                    if entry.use_rule not in used_rules:
+                        used_rules.add(entry.use_rule)
+                        changed = True
+    for rule_name in config.structure_rules.keys():
+        if rule_name not in used_rules:
+            warnings.append(
+                ScanIssue(
+                    severity="warning",
+                    code="unused_structure_rule",
+                    message=f"Unused structure rule '{rule_name}'",
+                    path=None,
                 )
-    except Exception:  # pylint: disable=broad-exception-caught  # pragma: no cover
-        pass
+            )
 
     return errors, warnings

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -297,47 +297,10 @@ def scan_full_repository(
     else:
         # Process each mapped directory independently, collecting errors
         for map_dir in config.directory_map:
-            try:
-                _process_map_dir(map_dir, repo_root, config, flags)
-            except MissingRequiredEntriesError as e:
-                errors.append(
-                    ScanIssue(
-                        severity="error",
-                        code="missing_required_entries",
-                        message=str(e),
-                        path=map_dir,
-                    )
-                )
-            except UnspecifiedEntryError as e:
-                errors.append(
-                    ScanIssue(
-                        severity="error",
-                        code="unspecified_entry",
-                        message=str(e),
-                        path=map_dir,
-                    )
-                )
-            except ForbiddenEntryError as e:
-                errors.append(
-                    ScanIssue(
-                        severity="error",
-                        code="forbidden_entry",
-                        message=str(e),
-                        path=map_dir,
-                    )
-                )
-            except (
-                Exception
-            ) as e:  # pylint: disable=broad-exception-caught,W0718  # pragma: no cover
-                # Fallback catch-all to avoid breaking non-throwing contract
-                errors.append(
-                    ScanIssue(
-                        severity="error",
-                        code="internal_error",
-                        message=str(e),
-                        path=map_dir,
-                    )
-                )
+            map_dir_errors = _process_map_dir_with_return_values(
+                map_dir, repo_root, config, flags
+            )
+            errors.extend(map_dir_errors)
 
     warnings: List[ScanIssue] = []
     # Compute unused rule warnings (do not throw)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,9 @@ jsonschema==4.25.1 \
     --hash=sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63 \
     --hash=sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85
     # via repo-structure (pyproject.toml)
-jsonschema-specifications==2025.4.1 \
-    --hash=sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af \
-    --hash=sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608
+jsonschema-specifications==2025.9.1 \
+    --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe \
+    --hash=sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d
     # via jsonschema
 referencing==0.36.2 \
     --hash=sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa \


### PR DESCRIPTION
## Summary
- Add `_process_map_dir_with_return_values` function as an alternative to `_process_map_dir`
- Returns `List[ScanIssue]` instead of raising exceptions
- Follows the same interface pattern used in `scan_full_repository`

## Test plan
- [x] All existing tests pass
- [x] Function reuses existing validation logic with minimal code duplication
- [x] Pre-commit hooks pass (linting, formatting, type checking)

🤖 Generated with [Claude Code](https://claude.ai/code)