### PR TITLE
Remove Python 3.9 support, require Python >=3.10

### DIFF
--- a/.github/workflows/build-and-test-ci.yaml
+++ b/.github/workflows/build-and-test-ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-24.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     permissions:

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ The rule can
 
 ## System Requirements
 
-- Tested with Python versions ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+- Tested with Python versions ["3.10", "3.11", "3.12", "3.13", "3.14"]
 - [Pip requirements](requirements.txt)
 - Does not work on Windows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,15 @@ name = "repo-structure"
 authors = [{name = "Jochen Issing", email = "c.333+git@nesono.com"}]
 description = "Check the directory structure of your repository"
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 license = "BSD-3-Clause"
 
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
This PR removes support for Python 3.9 and updates the minimum required Python version to 3.10.

## 🔄 Changes Made

### **CI/CD Updates**
- **GitHub Actions**: Updated test matrix from  to 
- **Cross-platform testing**: Continues to test on Ubuntu, macOS, and Windows

### **Project Configuration**
- **pyproject.toml**: Updated `requires-python` from `">=3.9,<4.0"` to `">=3.10,<4.0"`
- **Python classifiers**: Added specific version classifiers for Python 3.10, 3.11, 3.12, and 3.13
- **README**: Updated supported Python versions list

## 🎯 Rationale

1. **End of Life**: Python 3.9 reached end-of-life on October 31, 2025
2. **Modern Features**: Allows utilization of Python 3.10+ features like:
   - Structural pattern matching (`match`/`case`)
   - Union types with `|` syntax  
   - Improved type hints and `ParamSpec`
3. **Security**: Encourages users to use actively supported Python versions
4. **Maintenance**: Reduces testing burden and complexity

## 🔍 Impact

- **Breaking Change**: Users on Python 3.9 will need to upgrade to Python 3.10+
- **Dependencies**: All current dependencies support Python 3.10+
- **Compatibility**: No code changes needed - existing code remains compatible

## ✅ Testing

All existing tests pass on Python 3.10-3.13 across Windows, macOS, and Linux.