### PR TITLE
Fix Python version format in deploy workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Problem

The deploy action was failing with this error:
```
Error: The version '3.1' with architecture 'x64' was not found for Ubuntu 24.04.
```

## Root Cause

In the publish-to-pypi.yaml workflow, the Python version was specified as:
```yaml
python-version: 3.10
```

YAML was interpreting `3.10` as a decimal number `3.1`, not the string `"3.10"`. Since Python 3.1 was never officially released, GitHub Actions couldn't find this version.

## Solution

Changed the format to use explicit string quoting:
```yaml
python-version: "3.10"
```

This ensures YAML treats it as the string "3.10" instead of the decimal 3.1.

## Verification

- ✅ Other workflow files already use correct string format
- ✅ No similar issues found in build-and-test-ci.yaml or pre-commit.yml
- ✅ Small, focused change with no side effects