### PR TITLE
Add configuration reporting feature with optional descriptions

### DIFF
--- a/repo_structure.yaml
+++ b/repo_structure.yaml
@@ -20,6 +20,10 @@ structure_rules:
     - require: 'config\.schema\.json'
     - require: 'test_config_.*\.yaml'
 
+structure_rule_descriptions:
+  base_structure: "Core project files required for any repository including documentation, configuration, and tooling files"
+  python_package: "Standard Python package structure with modules, tests, and configuration files"
+
 directory_map:
   /:
     - use_rule: base_structure
@@ -27,3 +31,8 @@ directory_map:
     - use_rule: python_package
   /.github/:
     - use_rule: ignore
+
+directory_descriptions:
+  /: "Root directory containing project documentation, configuration files, and main project structure"
+  /repo_structure/: "Main Python package directory containing the core application logic and modules"
+  /.github/: "GitHub-specific configuration and workflow files - ignored from structure validation"

--- a/repo_structure/__main___test.py
+++ b/repo_structure/__main___test.py
@@ -284,3 +284,70 @@ def test_main_full_scan_directory_fail():
         ],
     )
     assert result.exit_code != 0
+
+
+def test_report_command_text():
+    """Test report command with text output."""
+    runner = CliRunner()
+    result = runner.invoke(
+        repo_structure,
+        [
+            "report",
+            "-c",
+            "repo_structure/test_config_allow_all.yaml",
+            "-f",
+            "text",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Repository Structure Configuration Report" in result.output
+    assert "Total Directories:" in result.output
+    assert "Total Structure Rules:" in result.output
+
+
+def test_report_command_json():
+    """Test report command with JSON output."""
+    runner = CliRunner()
+    result = runner.invoke(
+        repo_structure,
+        [
+            "report",
+            "-c",
+            "repo_structure/test_config_allow_all.yaml",
+            "-f",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert '"total_directories"' in result.output
+    assert '"total_structure_rules"' in result.output
+
+
+def test_report_command_markdown():
+    """Test report command with Markdown output."""
+    runner = CliRunner()
+    result = runner.invoke(
+        repo_structure,
+        [
+            "report",
+            "-c",
+            "repo_structure/test_config_allow_all.yaml",
+            "-f",
+            "markdown",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "# Repository Structure Configuration Report" in result.output
+    assert "**Total Directories:**" in result.output
+
+
+def test_report_command_help():
+    """Test report help command."""
+    runner = CliRunner()
+    result = runner.invoke(repo_structure, ["report", "--help"])
+
+    assert result.exit_code == 0
+    assert "Generate a report of the configuration structure" in result.output

--- a/repo_structure/config.schema.json
+++ b/repo_structure/config.schema.json
@@ -28,6 +28,7 @@
         "properties": {
           "use_rule": { "type": "string" },
           "use_template": { "type": "string" },
+          "description": { "type": "string" },
           "parameters": {
             "type": "object",
             "additionalProperties": {
@@ -64,6 +65,22 @@
       "type": "object",
       "patternProperties": {
         "^(?!__).*": { "$ref": "#/$defs/directory_entries" }
+      },
+      "additionalProperties": false
+    },
+    "structure_rule_descriptions": {
+      "description": "Optional descriptions for structure rules",
+      "type": "object",
+      "patternProperties": {
+        "^(?!__).*": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "directory_descriptions": {
+      "description": "Optional descriptions for directory mappings",
+      "type": "object",
+      "patternProperties": {
+        "^/.*/$|^/$": { "type": "string" }
       },
       "additionalProperties": false
     },

--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -30,6 +30,8 @@ class ConfigurationData:
     structure_rules: StructureRuleMap = field(default_factory=dict)
     directory_map: DirectoryMap = field(default_factory=dict)
     configuration_file_name: str = ""
+    structure_rule_descriptions: dict[str, str] = field(default_factory=dict)
+    directory_descriptions: dict[str, str] = field(default_factory=dict)
 
 
 class Configuration:
@@ -84,6 +86,10 @@ class Configuration:
                 yaml_dict.get("structure_rules", {})
             ),
             directory_map=_parse_directory_map(yaml_dict.get("directory_map", {})),
+            structure_rule_descriptions=yaml_dict.get(
+                "structure_rule_descriptions", {}
+            ),
+            directory_descriptions=yaml_dict.get("directory_descriptions", {}),
         )
         # Template parsing is expanded in-place and added as structure rules to the directory_map
         _parse_templates_to_configuration(
@@ -135,6 +141,16 @@ class Configuration:
     def configuration_file_name(self) -> str:
         """Property for configuration file name."""
         return self.config.configuration_file_name
+
+    @property
+    def structure_rule_descriptions(self) -> dict[str, str]:
+        """Property for structure rule descriptions."""
+        return self.config.structure_rule_descriptions
+
+    @property
+    def directory_descriptions(self) -> dict[str, str]:
+        """Property for directory descriptions."""
+        return self.config.directory_descriptions
 
 
 def _load_repo_structure_yaml(filename: str) -> dict:

--- a/repo_structure/repo_structure_report.py
+++ b/repo_structure/repo_structure_report.py
@@ -1,0 +1,280 @@
+"""Report generation functionality for repo structure configuration."""
+
+import json
+from dataclasses import dataclass
+from typing import Literal, Any
+from .repo_structure_config import Configuration
+from .repo_structure_lib import DirectoryMap, StructureRuleMap
+
+
+@dataclass
+class DirectoryReport:
+    """Report data for a single directory."""
+
+    directory: str
+    description: str
+    applied_rules: list[str]
+    rule_descriptions: list[str]
+
+
+@dataclass
+class StructureRuleReport:
+    """Report data for a single structure rule."""
+
+    rule_name: str
+    description: str
+    applied_directories: list[str]
+    directory_descriptions: list[str]
+    rule_count: int
+
+
+@dataclass
+class ConfigurationReport:
+    """Complete configuration report."""
+
+    directory_reports: list[DirectoryReport]
+    structure_rule_reports: list[StructureRuleReport]
+    total_directories: int
+    total_structure_rules: int
+
+
+def generate_report(config: Configuration) -> ConfigurationReport:
+    """Generate a comprehensive report of the configuration.
+
+    Args:
+        config: The configuration to generate a report for.
+
+    Returns:
+        A complete configuration report with directory and structure rule information.
+    """
+    directory_reports = _generate_directory_reports(
+        config.directory_map,
+        config.directory_descriptions,
+        config.structure_rule_descriptions,
+    )
+
+    structure_rule_reports = _generate_structure_rule_reports(
+        config.structure_rules,
+        config.directory_map,
+        config.structure_rule_descriptions,
+        config.directory_descriptions,
+    )
+
+    return ConfigurationReport(
+        directory_reports=directory_reports,
+        structure_rule_reports=structure_rule_reports,
+        total_directories=len(directory_reports),
+        total_structure_rules=len(structure_rule_reports),
+    )
+
+
+def _generate_directory_reports(
+    directory_map: DirectoryMap,
+    directory_descriptions: dict[str, str],
+    structure_rule_descriptions: dict[str, str],
+) -> list[DirectoryReport]:
+    """Generate reports for each directory mapping."""
+    reports = []
+
+    for directory, rules in directory_map.items():
+        rule_descriptions = [
+            structure_rule_descriptions.get(rule, "No description provided")
+            for rule in rules
+        ]
+
+        reports.append(
+            DirectoryReport(
+                directory=directory,
+                description=directory_descriptions.get(
+                    directory, "No description provided"
+                ),
+                applied_rules=rules,
+                rule_descriptions=rule_descriptions,
+            )
+        )
+
+    return sorted(reports, key=lambda x: x.directory)
+
+
+def _generate_structure_rule_reports(
+    structure_rules: StructureRuleMap,
+    directory_map: DirectoryMap,
+    structure_rule_descriptions: dict[str, str],
+    directory_descriptions: dict[str, str],
+) -> list[StructureRuleReport]:
+    """Generate reports for each structure rule."""
+    reports = []
+
+    for rule_name, rule_entries in structure_rules.items():
+        # Find directories that use this rule
+        applied_directories = [
+            directory
+            for directory, rules in directory_map.items()
+            if rule_name in rules
+        ]
+
+        directory_descs = [
+            directory_descriptions.get(directory, "No description provided")
+            for directory in applied_directories
+        ]
+
+        reports.append(
+            StructureRuleReport(
+                rule_name=rule_name,
+                description=structure_rule_descriptions.get(
+                    rule_name, "No description provided"
+                ),
+                applied_directories=applied_directories,
+                directory_descriptions=directory_descs,
+                rule_count=len(rule_entries),
+            )
+        )
+
+    return sorted(reports, key=lambda x: x.rule_name)
+
+
+def format_report_text(report: ConfigurationReport) -> str:
+    """Format the report as plain text.
+
+    Args:
+        report: The configuration report to format.
+
+    Returns:
+        A formatted text representation of the report.
+    """
+    lines = []
+    lines.append("Repository Structure Configuration Report")
+    lines.append("=" * 45)
+    lines.append("")
+    lines.append(f"Total Directories: {report.total_directories}")
+    lines.append(f"Total Structure Rules: {report.total_structure_rules}")
+    lines.append("")
+
+    # Directory dimension
+    lines.append("Directory Mappings")
+    lines.append("-" * 20)
+    for dir_report in report.directory_reports:
+        lines.append(f"Directory: {dir_report.directory}")
+        lines.append(f"  Description: {dir_report.description}")
+        lines.append(f"  Applied Rules: {', '.join(dir_report.applied_rules)}")
+        for rule, desc in zip(dir_report.applied_rules, dir_report.rule_descriptions):
+            lines.append(f"    - {rule}: {desc}")
+        lines.append("")
+
+    # Structure rule dimension
+    lines.append("Structure Rules")
+    lines.append("-" * 15)
+    for rule_report in report.structure_rule_reports:
+        lines.append(f"Rule: {rule_report.rule_name}")
+        lines.append(f"  Description: {rule_report.description}")
+        lines.append(f"  Entry Count: {rule_report.rule_count}")
+        lines.append(
+            f"  Applied to Directories: {', '.join(rule_report.applied_directories)}"
+        )
+        for directory, desc in zip(
+            rule_report.applied_directories, rule_report.directory_descriptions
+        ):
+            lines.append(f"    - {directory}: {desc}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_report_json(report: ConfigurationReport) -> str:
+    """Format the report as JSON.
+
+    Args:
+        report: The configuration report to format.
+
+    Returns:
+        A JSON representation of the report.
+    """
+
+    def convert_to_dict(obj: Any) -> Any:
+        """Convert dataclass to dictionary for JSON serialization."""
+        if hasattr(obj, "__dict__"):
+            result = {}
+            for key, value in obj.__dict__.items():
+                if isinstance(value, list):
+                    result[key] = [
+                        convert_to_dict(item) if hasattr(item, "__dict__") else item
+                        for item in value
+                    ]
+                else:
+                    result[key] = (
+                        convert_to_dict(value) if hasattr(value, "__dict__") else value
+                    )
+            return result
+        return obj
+
+    report_dict = convert_to_dict(report)
+    return json.dumps(report_dict, indent=2)
+
+
+def format_report_markdown(report: ConfigurationReport) -> str:
+    """Format the report as Markdown.
+
+    Args:
+        report: The configuration report to format.
+
+    Returns:
+        A Markdown representation of the report.
+    """
+    lines = []
+    lines.append("# Repository Structure Configuration Report")
+    lines.append("")
+    lines.append(f"**Total Directories:** {report.total_directories}  ")
+    lines.append(f"**Total Structure Rules:** {report.total_structure_rules}")
+    lines.append("")
+
+    # Directory dimension
+    lines.append("## Directory Mappings")
+    lines.append("")
+    for dir_report in report.directory_reports:
+        lines.append(f"### Directory: `{dir_report.directory}`")
+        lines.append("")
+        lines.append(f"**Description:** {dir_report.description}")
+        lines.append("")
+        lines.append("**Applied Rules:**")
+        for rule, desc in zip(dir_report.applied_rules, dir_report.rule_descriptions):
+            lines.append(f"- `{rule}`: {desc}")
+        lines.append("")
+
+    # Structure rule dimension
+    lines.append("## Structure Rules")
+    lines.append("")
+    for rule_report in report.structure_rule_reports:
+        lines.append(f"### Rule: `{rule_report.rule_name}`")
+        lines.append("")
+        lines.append(f"**Description:** {rule_report.description}  ")
+        lines.append(f"**Entry Count:** {rule_report.rule_count}")
+        lines.append("")
+        lines.append("**Applied to Directories:**")
+        for directory, desc in zip(
+            rule_report.applied_directories, rule_report.directory_descriptions
+        ):
+            lines.append(f"- `{directory}`: {desc}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_report(
+    report: ConfigurationReport,
+    format_type: Literal["text", "json", "markdown"] = "text",
+) -> str:
+    """Format the report in the specified format.
+
+    Args:
+        report: The configuration report to format.
+        format_type: The desired output format.
+
+    Returns:
+        A formatted representation of the report.
+    """
+    if format_type == "json":
+        return format_report_json(report)
+    elif format_type == "markdown":
+        return format_report_markdown(report)
+    else:
+        return format_report_text(report)

--- a/repo_structure/repo_structure_report_test.py
+++ b/repo_structure/repo_structure_report_test.py
@@ -1,0 +1,282 @@
+"""Tests for repo_structure report functionality."""
+
+from .repo_structure_config import Configuration
+from .repo_structure_report import (
+    generate_report,
+    format_report_text,
+    format_report_json,
+    format_report_markdown,
+    format_report,
+)
+
+
+def test_generate_report_basic():
+    """Test basic report generation with simple configuration."""
+    test_yaml = """
+structure_rules:
+  basic_rule:
+    - require: 'README\\.md'
+    - allow: '.*\\.txt'
+
+directory_map:
+  /:
+    - use_rule: basic_rule
+"""
+    config = Configuration(test_yaml, param1_is_yaml_string=True)
+    report = generate_report(config)
+
+    assert report.total_directories == 1
+    assert report.total_structure_rules == 1
+    assert len(report.directory_reports) == 1
+    assert len(report.structure_rule_reports) == 1
+
+    # Check directory report
+    dir_report = report.directory_reports[0]
+    assert dir_report.directory == "/"
+    assert dir_report.description == "No description provided"
+    assert dir_report.applied_rules == ["basic_rule"]
+
+    # Check structure rule report
+    rule_report = report.structure_rule_reports[0]
+    assert rule_report.rule_name == "basic_rule"
+    assert rule_report.description == "No description provided"
+    assert rule_report.applied_directories == ["/"]
+    assert rule_report.rule_count == 2
+
+
+def test_generate_report_with_descriptions():
+    """Test report generation with description fields."""
+    test_yaml = """
+structure_rules:
+  basic_rule:
+    - require: 'README\\.md'
+    - allow: '.*\\.txt'
+  python_rule:
+    - require: '__init__\\.py'
+    - require: '.*\\.py'
+
+structure_rule_descriptions:
+  basic_rule: "Basic documentation and text files"
+  python_rule: "Standard Python package structure"
+
+directory_map:
+  /:
+    - use_rule: basic_rule
+  /src/:
+    - use_rule: python_rule
+
+directory_descriptions:
+  /: "Root directory with documentation"
+  /src/: "Source code directory"
+"""
+    config = Configuration(test_yaml, param1_is_yaml_string=True)
+    report = generate_report(config)
+
+    assert report.total_directories == 2
+    assert report.total_structure_rules == 2
+
+    # Check directory descriptions are included
+    root_dir = next(d for d in report.directory_reports if d.directory == "/")
+    assert root_dir.description == "Root directory with documentation"
+
+    src_dir = next(d for d in report.directory_reports if d.directory == "/src/")
+    assert src_dir.description == "Source code directory"
+
+    # Check structure rule descriptions are included
+    basic_rule = next(
+        r for r in report.structure_rule_reports if r.rule_name == "basic_rule"
+    )
+    assert basic_rule.description == "Basic documentation and text files"
+
+    python_rule = next(
+        r for r in report.structure_rule_reports if r.rule_name == "python_rule"
+    )
+    assert python_rule.description == "Standard Python package structure"
+
+
+def test_format_report_text():
+    """Test text formatting of report."""
+    test_yaml = """
+structure_rules:
+  basic_rule:
+    - require: 'README\\.md'
+
+directory_map:
+  /:
+    - use_rule: basic_rule
+
+structure_rule_descriptions:
+  basic_rule: "Basic rule description"
+
+directory_descriptions:
+  /: "Root directory description"
+"""
+    config = Configuration(test_yaml, param1_is_yaml_string=True)
+    report = generate_report(config)
+    text_output = format_report_text(report)
+
+    assert "Repository Structure Configuration Report" in text_output
+    assert "Total Directories: 1" in text_output
+    assert "Total Structure Rules: 1" in text_output
+    assert "Directory: /" in text_output
+    assert "Root directory description" in text_output
+    assert "Rule: basic_rule" in text_output
+    assert "Basic rule description" in text_output
+
+
+def test_format_report_json():
+    """Test JSON formatting of report."""
+    test_yaml = """
+structure_rules:
+  basic_rule:
+    - require: 'README\\.md'
+
+directory_map:
+  /:
+    - use_rule: basic_rule
+"""
+    config = Configuration(test_yaml, param1_is_yaml_string=True)
+    report = generate_report(config)
+    json_output = format_report_json(report)
+
+    assert '"total_directories": 1' in json_output
+    assert '"total_structure_rules": 1' in json_output
+    assert '"directory": "/"' in json_output
+    assert '"rule_name": "basic_rule"' in json_output
+
+
+def test_format_report_markdown():
+    """Test Markdown formatting of report."""
+    test_yaml = """
+structure_rules:
+  basic_rule:
+    - require: 'README\\.md'
+
+directory_map:
+  /:
+    - use_rule: basic_rule
+
+structure_rule_descriptions:
+  basic_rule: "Basic rule description"
+"""
+    config = Configuration(test_yaml, param1_is_yaml_string=True)
+    report = generate_report(config)
+    markdown_output = format_report_markdown(report)
+
+    assert "# Repository Structure Configuration Report" in markdown_output
+    assert "**Total Directories:** 1" in markdown_output
+    assert "### Directory: `/`" in markdown_output
+    assert "### Rule: `basic_rule`" in markdown_output
+    assert "Basic rule description" in markdown_output
+
+
+def test_format_report_function():
+    """Test the format_report function with different formats."""
+    test_yaml = """
+structure_rules:
+  basic_rule:
+    - require: 'README\\.md'
+
+directory_map:
+  /:
+    - use_rule: basic_rule
+"""
+    config = Configuration(test_yaml, param1_is_yaml_string=True)
+    report = generate_report(config)
+
+    # Test text format (default)
+    text_output = format_report(report)
+    assert "Repository Structure Configuration Report" in text_output
+
+    # Test explicit text format
+    text_output_explicit = format_report(report, "text")
+    assert text_output == text_output_explicit
+
+    # Test JSON format
+    json_output = format_report(report, "json")
+    assert '"total_directories": 1' in json_output
+
+    # Test Markdown format
+    markdown_output = format_report(report, "markdown")
+    assert "# Repository Structure Configuration Report" in markdown_output
+
+
+def test_multiple_rules_per_directory():
+    """Test report generation with multiple rules applied to a directory."""
+    test_yaml = """
+structure_rules:
+  rule1:
+    - require: 'README\\.md'
+  rule2:
+    - require: 'LICENSE'
+
+directory_map:
+  /:
+    - use_rule: rule1
+    - use_rule: rule2
+
+structure_rule_descriptions:
+  rule1: "Documentation rule"
+  rule2: "License rule"
+"""
+    config = Configuration(test_yaml, param1_is_yaml_string=True)
+    report = generate_report(config)
+
+    dir_report = report.directory_reports[0]
+    assert dir_report.applied_rules == ["rule1", "rule2"]
+    assert dir_report.rule_descriptions == ["Documentation rule", "License rule"]
+
+    # Both rules should show they're applied to root
+    for rule_report in report.structure_rule_reports:
+        assert "/" in rule_report.applied_directories
+
+
+def test_empty_configuration():
+    """Test report generation with minimal configuration."""
+    test_yaml = """
+structure_rules:
+  dummy_rule:
+    - allow: '.*'
+
+directory_map:
+  /:
+    - use_rule: ignore
+"""
+    config = Configuration(test_yaml, param1_is_yaml_string=True)
+    report = generate_report(config)
+
+    assert report.total_directories == 1
+    assert report.total_structure_rules == 1  # dummy_rule is counted
+    assert len(report.directory_reports) == 1
+    assert len(report.structure_rule_reports) == 1
+
+    dir_report = report.directory_reports[0]
+    assert dir_report.directory == "/"
+    assert dir_report.applied_rules == ["ignore"]
+
+
+def test_sorting():
+    """Test that reports are sorted correctly."""
+    test_yaml = """
+structure_rules:
+  z_rule:
+    - require: 'README\\.md'
+  a_rule:
+    - require: 'LICENSE'
+
+directory_map:
+  /z/:
+    - use_rule: z_rule
+  /a/:
+    - use_rule: a_rule
+"""
+    config = Configuration(test_yaml, param1_is_yaml_string=True)
+    report = generate_report(config)
+
+    # Directories should be sorted
+    directories = [d.directory for d in report.directory_reports]
+    assert directories == ["/a/", "/z/"]
+
+    # Rules should be sorted
+    rules = [r.rule_name for r in report.structure_rule_reports]
+    assert rules == ["a_rule", "z_rule"]


### PR DESCRIPTION
## Summary
This PR adds a comprehensive reporting feature that allows users to generate reports of their repository structure configuration with optional descriptions for better documentation and understanding.

## Key Features
- **Optional description fields** for structure rules and directory mappings
- **Two-dimensional analysis**:
  - Directory dimension: Shows directories and their applied rules with descriptions
  - Structure rule dimension: Shows rules and where they're applied with descriptions
- **Multiple output formats**: text, JSON, and Markdown
- **New CLI command** `report` with format and output file options
- **Full backward compatibility** - descriptions are optional
- **Comprehensive test coverage** for all new functionality

## Schema Changes
- Extended JSON schema to support `structure_rule_descriptions` and `directory_descriptions`
- Updated configuration parsing to handle new optional fields

## CLI Usage Examples
```bash
# Generate text report
repo-structure report

# Generate JSON report
repo-structure report -f json

# Generate Markdown report and save to file
repo-structure report -f markdown -o report.md
```

## Example Configuration with Descriptions
```yaml
structure_rules:
  base_structure:
    - require: "README\\.md"
    - require: "LICENSE"
  python_package:
    - require: "__init__\\.py"
    - require: ".*\\.py"

structure_rule_descriptions:
  base_structure: "Core project files required for any repository"
  python_package: "Standard Python package structure"

directory_map:
  /:
    - use_rule: base_structure
  /src/:
    - use_rule: python_package

directory_descriptions:
  /: "Root directory with documentation and configuration"
  /src/: "Source code directory"
```

## Test Plan
- [x] All existing tests continue to pass
- [x] New report functionality tests added and passing
- [x] CLI integration tests added and passing
- [x] Backward compatibility verified with existing configurations
- [x] Multiple output formats tested (text, JSON, Markdown)

🤖 Generated with [Claude Code](https://claude.ai/code)