### PR TITLE
Phase 1.1: Replace mutable Flags() default arguments

### DIFF
--- a/repo_structure/repo_structure_diff_scan.py
+++ b/repo_structure/repo_structure_diff_scan.py
@@ -28,7 +28,7 @@ from .repo_structure_lib import (
 class DiffScanProcessor:
     """Handles differential scanning of specific paths with stateful configuration."""
 
-    def __init__(self, config: Configuration, flags: Flags = Flags()):
+    def __init__(self, config: Configuration, flags: Flags | None = None):
         """Initialize the diff scanner with static configuration.
 
         Args:
@@ -36,7 +36,7 @@ class DiffScanProcessor:
             flags: Scanning flags (verbose, follow_symlinks, include_hidden)
         """
         self.config = config
-        self.flags = flags
+        self.flags = flags if flags is not None else Flags()
 
     def _incremental_path_split(
         self, path_to_split: str

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -29,7 +29,12 @@ from .repo_structure_lib import (
 class FullScanProcessor:
     """Handles full repository structure scanning."""
 
-    def __init__(self, repo_root: str, config: Configuration, flags: Flags = Flags()):
+    def __init__(
+        self,
+        repo_root: str,
+        config: Configuration,
+        flags: Flags | None = None,
+    ):
         """Initialize the scanner with static configuration.
 
         Args:
@@ -39,7 +44,7 @@ class FullScanProcessor:
         """
         self.repo_root = repo_root
         self.config = config
-        self.flags = flags
+        self.flags = flags if flags is not None else Flags()
         self.git_ignore = self._get_git_ignore()
 
     def _get_git_ignore(self) -> Callable[[str], bool] | None:

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -205,9 +205,11 @@ def skip_entry(
     directory_map: DirectoryMap,
     config_file_name: str,
     git_ignore: Callable[[str], bool] | None = None,
-    flags: Flags = Flags(),
+    flags: Flags | None = None,
 ) -> bool:
     """Return True if the entry should be skipped/ignored."""
+    if flags is None:
+        flags = Flags()
     skip_conditions = [
         (not flags.follow_symlinks and entry.is_symlink),
         (not flags.include_hidden and entry.path.startswith(".")),


### PR DESCRIPTION
## Summary

- Replaces `flags: Flags = Flags()` with `flags: Flags | None = None` in `skip_entry`, `FullScanProcessor.__init__`, `DiffScanProcessor.__init__`.
- Instantiates a fresh `Flags()` inside each function when the caller passes `None`.

This fixes the latent Python mutable-default-argument bug where a single shared `Flags` instance is used across all calls.

Closes #164

## Test plan

- [x] `uv run --extra dev pytest -q` — 185 passed
- [x] Pre-commit hooks (mypy, pylint, ruff, black) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)