### PR TITLE
Phase 1.4: Add message to empty ConfigurationParseError

### DIFF
--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -72,7 +72,10 @@ class Configuration:
             yaml_dict = _load_repo_structure_yaml(config_file)
 
         if not yaml_dict:
-            raise ConfigurationParseError
+            source = "yaml string" if param1_is_yaml_string else config_file
+            raise ConfigurationParseError(
+                f"Configuration is empty or could not be parsed: {source}"
+            )
 
         if not schema:
             schema = get_json_schema()


### PR DESCRIPTION
## Summary

- Provides a diagnostic message when `Configuration` is built from an empty YAML, mentioning the source (file path or "yaml string").

Closes #167

## Test plan

- [x] `uv run --extra dev pytest -q` — 185 passed
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)