### PR TITLE
Phase 1.5: Escape regex metacharacters in captured values

### DIFF
--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -114,23 +114,26 @@ def map_dir_to_rel_dir(map_dir: str) -> str:
 
 
 def substitute_pattern_captures(pattern_template: str, captures: dict[str, str]) -> str:
-    """Substitute captured group values into a pattern template.
+    r"""Substitute captured group values into a pattern template.
+
+    Captured values are passed through ``re.escape`` so any regex
+    metacharacters in the captured filename are treated as literals.
 
     Args:
         pattern_template: Pattern string with {{name}} placeholders
         captures: Dictionary mapping capture group names to their values
 
     Returns:
-        Pattern string with placeholders replaced by captured values
+        Pattern string with placeholders replaced by escaped captured values
 
     Example:
         >>> substitute_pattern_captures("{{base}}.h", {"base": "foo"})
-        'foo.h'
+        'foo\\.h'
     """
     result = pattern_template
     for name, value in captures.items():
         placeholder = f"{{{{{name}}}}}"
-        result = result.replace(placeholder, value)
+        result = result.replace(placeholder, re.escape(value))
     return result
 
 
@@ -175,15 +178,19 @@ def expand_companion_requirements(
     """
     expanded = []
     for template in companion_templates:
-        # Substitute captures in the pattern
+        # Substitute captures in the pattern (values are re.escaped)
         expanded_pattern = substitute_pattern_captures(template.path.pattern, captures)
 
-        # Create a new RepoEntry with the expanded pattern
+        # Compilation failures here indicate a malformed template (not a bad
+        # capture value, since those are escaped). Surface them instead of
+        # silently dropping required companion checks.
         try:
             compiled_pattern = re.compile(expanded_pattern)
-        except re.error:
-            # If pattern compilation fails, skip this companion
-            continue
+        except re.error as exc:
+            raise StructureRuleError(
+                f"Companion pattern '{template.path.pattern}' expanded to "
+                f"'{expanded_pattern}' which failed to compile: {exc}"
+            ) from exc
 
         expanded_entry = RepoEntry(
             path=compiled_pattern,

--- a/repo_structure/repo_structure_lib_test.py
+++ b/repo_structure/repo_structure_lib_test.py
@@ -591,16 +591,19 @@ class TestPatternCaptureAndSubstitution:
         assert expanded[1].path.pattern == "widget_test.cpp"
         assert not expanded[1].is_required
 
-    def test_expand_companion_requirements_invalid_pattern(self):
-        """Test that invalid patterns after substitution are skipped."""
+    def test_expand_companion_requirements_escapes_capture_metacharacters(self):
+        """Capture values containing regex metacharacters are escaped, not interpreted."""
         companion_template = RepoEntry(
-            path=re.compile("{{base}}\\.h"),  # Valid template
+            path=re.compile("{{base}}\\.h"),
             is_dir=False,
             is_required=True,
             is_forbidden=False,
         )
-        captures = {"base": "foo(bar"}  # Will create invalid pattern "foo(bar.h"
+        # A literal "foo(bar" capture would have previously yielded an invalid
+        # pattern; re.escape now keeps it as a literal match string.
+        captures = {"base": "foo(bar"}
         expanded = expand_companion_requirements([companion_template], captures)
 
-        # Should skip the invalid pattern
-        assert len(expanded) == 0
+        assert len(expanded) == 1
+        # The resulting compiled pattern matches the literal "foo(bar.h"
+        assert expanded[0].path.fullmatch("foo(bar.h") is not None


### PR DESCRIPTION
## Summary

- Passes captured filename values through `re.escape` before substituting them into companion pattern templates.
- Stops swallowing `re.error` in `expand_companion_requirements`; raises `StructureRuleError` instead, since an expanded template that fails to compile after escaping captures indicates a malformed template, not bad user data.

Closes #168

## Test plan

- [x] `uv run --extra dev pytest -q` — 185 passed
- [x] Replaced the now-obsolete "invalid pattern swallowed" test with one verifying that metacharacter-containing captures are matched literally
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)