### PR TITLE
Phase 1.6: Fix typo, double space, dangling fmt:off

### DIFF
--- a/repo_structure/__init__.py
+++ b/repo_structure/__init__.py
@@ -1,4 +1,4 @@
-"""Check the repository directory strucgure against your configuration."""
+"""Check the repository directory structure against your configuration."""
 
 from .repo_structure_config import Configuration
 from .repo_structure_full_scan import FullScanProcessor

--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -381,9 +381,10 @@ def _parse_use_template(
         if not ("description" in entry and len(entry) == 1)
     ]
 
-    # fmt: off
-    template_rule_name = \
-        f"__template_rule_{map_dir_to_rel_dir(directory)}_{dir_map_yaml['use_template']}"
+    template_rule_name = (
+        f"__template_rule_{map_dir_to_rel_dir(directory)}_"
+        f"{dir_map_yaml['use_template']}"
+    )
     config.config.structure_rules[template_rule_name] = structure_rule_list
     config.config.directory_map[directory].append(template_rule_name)
 

--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -378,9 +378,10 @@ def _parse_use_template(
         if not ("description" in entry and len(entry) == 1)
     ]
 
-    # fmt: off
-    template_rule_name = \
-        f"__template_rule_{map_dir_to_rel_dir(directory)}_{dir_map_yaml['use_template']}"
+    template_rule_name = (
+        f"__template_rule_{map_dir_to_rel_dir(directory)}_"
+        f"{dir_map_yaml['use_template']}"
+    )
     config.config.structure_rules[template_rule_name] = structure_rule_list
     config.config.directory_map[directory].append(template_rule_name)
 

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -65,7 +65,7 @@ class FullScanProcessor:
         def _format_missing_entries_message(
             missing_files: list[str], missing_dirs: list[str]
         ) -> str:
-            result = f"Required patterns missing in  directory '{rel_dir}':\n"
+            result = f"Required patterns missing in directory '{rel_dir}':\n"
             if missing_files:
                 result += "Files:\n"
                 result += "".join(f"  - '{file}'\n" for file in missing_files)

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -58,7 +58,7 @@ class FullScanProcessor:
         def _format_missing_entries_message(
             missing_files: list[str], missing_dirs: list[str]
         ) -> str:
-            result = f"Required patterns missing in  directory '{rel_dir}':\n"
+            result = f"Required patterns missing in directory '{rel_dir}':\n"
             if missing_files:
                 result += "Files:\n"
                 result += "".join(f"  - '{file}'\n" for file in missing_files)


### PR DESCRIPTION
## Summary

- Fix \`strucgure\` typo in the package docstring.
- Remove the doubled space in the missing-required-entries error message (\`in  directory\` -> \`in directory\`).
- Replace the dangling \`# fmt: off\` and explicit-continuation line in \`_parse_use_template\` with a regular f-string so the block is again subject to the formatter.

Closes #169

## Test plan

- [x] \`uv run --extra dev pytest -q\` — 185 passed
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)