### PR TITLE
Phase 2.1: Switch verbose prints to logging module

### DIFF
--- a/repo_structure/__main__.py
+++ b/repo_structure/__main__.py
@@ -1,5 +1,6 @@
 """Ensure clean repository structure for your projects."""
 
+import logging
 import sys
 from typing import cast
 from typing import Literal
@@ -57,6 +58,12 @@ def repo_structure(
     verbose: bool,
 ) -> None:
     """Ensure clean repository structure for your projects."""
+    if verbose:
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="%(message)s",
+            stream=sys.stdout,
+        )
     flags = Flags()
     flags.follow_symlinks = follow_symlinks
     flags.include_hidden = include_hidden

--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -1,7 +1,7 @@
 """Library functions for repo structure config parsing."""
 
 import copy
-import pprint
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import TextIO, Any
@@ -21,6 +21,8 @@ from .repo_structure_lib import (
     TemplateError,
 )
 from .repo_structure_schema import get_json_schema
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -65,7 +67,8 @@ class Configuration:
             ConfigurationParseError: Raised for errors during the configuration parsing process.
         """
         if verbose:
-            print("Loading configuration")
+            logging.getLogger(__package__).setLevel(logging.DEBUG)
+        _LOGGER.debug("Loading configuration")
         if param1_is_yaml_string:
             yaml_dict = _load_repo_structure_yamls(config_file)
         else:
@@ -86,11 +89,8 @@ class Configuration:
             raise ConfigurationParseError(f"Bad config: {e.message}") from e
         except SchemaError as e:
             raise ConfigurationParseError(f"Bad schema: {e.message}") from e
-        if verbose:
-            print("Configuration validated successfully")
-
-        if verbose:
-            print("Parsing configuration data")
+        _LOGGER.debug("Configuration validated successfully")
+        _LOGGER.debug("Parsing configuration data")
 
         structure_rules, structure_rule_descriptions = _parse_structure_rules(
             yaml_dict.get("structure_rules", {})
@@ -122,15 +122,12 @@ class Configuration:
 
             self.config.configuration_file_name = config_file
 
-        if verbose:
-            # Print the parsed configuration pretty
-            pprint.pprint(self.config.directory_map, indent=2)
-            pprint.pprint(self.config.structure_rules, indent=2)
-            print(
-                f"Structure rules count: {len(self.config.structure_rules.keys())}, "
-                f"Directory map count: {len(self.config.directory_map.keys())}"
-            )
-            print("Configuration parsed successfully")
+        _LOGGER.debug(
+            "Structure rules count: %d, Directory map count: %d",
+            len(self.config.structure_rules),
+            len(self.config.directory_map),
+        )
+        _LOGGER.debug("Configuration parsed successfully")
 
     def _validate_directory_map_use_rules(self):
         existing_rules = self.config.structure_rules.keys()

--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -1,7 +1,7 @@
 """Library functions for repo structure config parsing."""
 
 import copy
-import pprint
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import TextIO, Any
@@ -21,6 +21,8 @@ from .repo_structure_lib import (
     TemplateError,
 )
 from .repo_structure_schema import get_json_schema
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -65,7 +67,8 @@ class Configuration:
             ConfigurationParseError: Raised for errors during the configuration parsing process.
         """
         if verbose:
-            print("Loading configuration")
+            logging.getLogger(__package__).setLevel(logging.DEBUG)
+        _LOGGER.debug("Loading configuration")
         if param1_is_yaml_string:
             yaml_dict = _load_repo_structure_yamls(config_file)
         else:
@@ -83,11 +86,8 @@ class Configuration:
             raise ConfigurationParseError(f"Bad config: {e.message}") from e
         except SchemaError as e:
             raise ConfigurationParseError(f"Bad schema: {e.message}") from e
-        if verbose:
-            print("Configuration validated successfully")
-
-        if verbose:
-            print("Parsing configuration data")
+        _LOGGER.debug("Configuration validated successfully")
+        _LOGGER.debug("Parsing configuration data")
 
         structure_rules, structure_rule_descriptions = _parse_structure_rules(
             yaml_dict.get("structure_rules", {})
@@ -119,15 +119,12 @@ class Configuration:
 
             self.config.configuration_file_name = config_file
 
-        if verbose:
-            # Print the parsed configuration pretty
-            pprint.pprint(self.config.directory_map, indent=2)
-            pprint.pprint(self.config.structure_rules, indent=2)
-            print(
-                f"Structure rules count: {len(self.config.structure_rules.keys())}, "
-                f"Directory map count: {len(self.config.directory_map.keys())}"
-            )
-            print("Configuration parsed successfully")
+        _LOGGER.debug(
+            "Structure rules count: %d, Directory map count: %d",
+            len(self.config.structure_rules),
+            len(self.config.directory_map),
+        )
+        _LOGGER.debug("Configuration parsed successfully")
 
     def _validate_directory_map_use_rules(self):
         existing_rules = self.config.structure_rules.keys()

--- a/repo_structure/repo_structure_diff_scan.py
+++ b/repo_structure/repo_structure_diff_scan.py
@@ -1,5 +1,6 @@
 """Library functions for repo structure directory verification."""
 
+import logging
 from pathlib import Path
 from typing import Iterator
 
@@ -24,6 +25,8 @@ from .repo_structure_lib import (
     check_companion_files,
     MatchFailure,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class DiffScanProcessor:
@@ -94,8 +97,7 @@ class DiffScanProcessor:
             if isinstance(match_result, MatchFailure):
                 return match_result.issue
 
-            if self.flags.verbose:
-                print(f"  Found match for path '{entry_name}'")
+            _LOGGER.debug("  Found match for path '%s'", entry_name)
 
             # Check for required companion files
             backlog_match = backlog[match_result.index]
@@ -128,8 +130,7 @@ class DiffScanProcessor:
             if is_dir and map_sub_dir in self.config.directory_map:
                 map_dir = map_sub_dir
 
-        if self.flags.verbose:
-            print(f"Found corresponding map dir for '{path}': '{map_dir}'")
+        _LOGGER.debug("Found corresponding map dir for '%s': '%s'", path, map_dir)
 
         return map_dir
 
@@ -151,8 +152,7 @@ class DiffScanProcessor:
             map_dir_to_rel_dir(map_dir),
         )
         if not backlog:
-            if self.flags.verbose:
-                print("backlog empty - returning success")
+            _LOGGER.debug("backlog empty - returning success")
             return None
 
         base_dir = map_dir_to_rel_dir(map_dir)

--- a/repo_structure/repo_structure_diff_scan.py
+++ b/repo_structure/repo_structure_diff_scan.py
@@ -1,5 +1,6 @@
 """Library functions for repo structure directory verification."""
 
+import logging
 from pathlib import Path
 from typing import Iterator
 
@@ -23,6 +24,8 @@ from .repo_structure_lib import (
     get_matching_item_index,
     check_companion_files,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class DiffScanProcessor:
@@ -93,8 +96,7 @@ class DiffScanProcessor:
             if not match_result.success:
                 return match_result.issue
 
-            if self.flags.verbose:
-                print(f"  Found match for path '{entry_name}'")
+            _LOGGER.debug("  Found match for path '%s'", entry_name)
 
             # Check for required companion files
             idx = match_result.index
@@ -129,8 +131,7 @@ class DiffScanProcessor:
             if is_dir and map_sub_dir in self.config.directory_map:
                 map_dir = map_sub_dir
 
-        if self.flags.verbose:
-            print(f"Found corresponding map dir for '{path}': '{map_dir}'")
+        _LOGGER.debug("Found corresponding map dir for '%s': '%s'", path, map_dir)
 
         return map_dir
 
@@ -152,8 +153,7 @@ class DiffScanProcessor:
             map_dir_to_rel_dir(map_dir),
         )
         if not backlog:
-            if self.flags.verbose:
-                print("backlog empty - returning success")
+            _LOGGER.debug("backlog empty - returning success")
             return None
 
         base_dir = map_dir_to_rel_dir(map_dir)

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -1,5 +1,6 @@
 """Library functions for repo structure directory verification."""
 
+import logging
 import os
 
 from pathlib import Path
@@ -26,6 +27,8 @@ from .repo_structure_lib import (
     check_companion_files,
     MatchFailure,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class FullScanProcessor:
@@ -109,8 +112,7 @@ class FullScanProcessor:
         for os_entry in entries:
             entry = to_entry(os_entry, rel_dir)
 
-            if self.flags.verbose:
-                print(f"Checking entry {entry.path}")
+            _LOGGER.debug("Checking entry %s", entry.path)
 
             if self._should_skip_entry(entry):
                 continue
@@ -200,8 +202,7 @@ class FullScanProcessor:
         )
 
         if not backlog:
-            if self.flags.verbose:
-                print("backlog empty - returning success")
+            _LOGGER.debug("backlog empty - returning success")
             return errors
 
         # Check repository structure using non-throwing functions

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -1,5 +1,6 @@
 """Library functions for repo structure directory verification."""
 
+import logging
 import os
 
 from pathlib import Path
@@ -24,6 +25,8 @@ from .repo_structure_lib import (
     get_matching_item_index,
     check_companion_files,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class FullScanProcessor:
@@ -102,8 +105,7 @@ class FullScanProcessor:
         for os_entry in entries:
             entry = to_entry(os_entry, rel_dir)
 
-            if self.flags.verbose:
-                print(f"Checking entry {entry.path}")
+            _LOGGER.debug("Checking entry %s", entry.path)
 
             if self._should_skip_entry(entry):
                 continue
@@ -190,8 +192,7 @@ class FullScanProcessor:
         )
 
         if not backlog:
-            if self.flags.verbose:
-                print("backlog empty - returning success")
+            _LOGGER.debug("backlog empty - returning success")
             return errors
 
         # Check repository structure using non-throwing functions

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -1,5 +1,6 @@
 """Common library code for repo_structure."""
 
+import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -8,6 +9,8 @@ from pathlib import Path
 from typing import Callable, Final, Literal
 
 BUILTIN_DIRECTORY_RULES: Final = ["ignore"]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ConfigurationParseError(Exception):
@@ -233,8 +236,7 @@ def skip_entry(
 
     for condition in skip_conditions:
         if condition:
-            if flags.verbose:
-                print(f"Skipping {entry.path}")
+            _LOGGER.debug("Skipping %s", entry.path)
             return True
 
     return False
@@ -253,13 +255,12 @@ def to_entry(os_entry: DirEntry[str], rel_dir: str) -> Entry:
 def expand_use_rule(
     use_rule: str,
     structure_rules: StructureRuleMap,
-    flags: Flags,
+    flags: Flags,  # pylint: disable=unused-argument
     rel_path: str,
 ):
     """Expand the use_rule into a list of RepoEntry items."""
     if use_rule:
-        if flags.verbose:
-            print(f"use_rule found for rel path '{rel_path}'")
+        _LOGGER.debug("use_rule found for rel path '%s'", rel_path)
         return _build_active_entry_backlog(
             [use_rule],
             structure_rules,
@@ -267,11 +268,12 @@ def expand_use_rule(
     return None
 
 
-def expand_if_exists(backlog_entry: RepoEntry, flags: Flags):
+def expand_if_exists(
+    backlog_entry: RepoEntry, flags: Flags
+):  # pylint: disable=unused-argument
     """Expand to the entry in `if_exists` or None."""
     if backlog_entry.if_exists:
-        if flags.verbose:
-            print(f"if_exists found for rel path '{backlog_entry.path.pattern}'")
+        _LOGGER.debug("if_exists found for rel path '%s'", backlog_entry.path.pattern)
         return backlog_entry.if_exists
     # the following line can not be reached given a directory entry must be
     # either `use_rule`, or `if_exists`
@@ -380,7 +382,7 @@ def get_matching_item_index(
     backlog: StructureRuleList,
     entry_path: str,
     is_dir: bool,
-    verbose: bool = False,
+    verbose: bool = False,  # pylint: disable=unused-argument
 ) -> MatchResult:
     """Get matching item index without raising exceptions, return result with potential issues."""
     for i, v in enumerate(backlog):
@@ -394,8 +396,7 @@ def get_matching_item_index(
                         path=entry_path,
                     )
                 )
-            if verbose:
-                print(f"  Found match at index {i}: '{v.path.pattern}'")
+            _LOGGER.debug("  Found match at index %d: '%s'", i, v.path.pattern)
             return MatchSuccess(index=i)
 
     display_path = entry_path + "/" if is_dir else entry_path
@@ -410,7 +411,9 @@ def get_matching_item_index(
 
 
 def _find_matching_file_in_directory(
-    base_dir: str, pattern: re.Pattern, verbose: bool
+    base_dir: str,
+    pattern: re.Pattern,
+    verbose: bool,  # pylint: disable=unused-argument
 ) -> bool:
     """Find a file matching the pattern in the directory tree.
 
@@ -433,8 +436,7 @@ def _find_matching_file_in_directory(
             file_rel_normalized = normalize_path(str(file_rel))
 
             if pattern.fullmatch(file_rel_normalized):
-                if verbose:
-                    print(f"  Found companion: {file_rel_normalized}")
+                _LOGGER.debug("  Found companion: %s", file_rel_normalized)
                 return True
 
     return False
@@ -479,8 +481,9 @@ def check_companion_files(
 
         # Search for file matching the companion pattern
         if not _find_matching_file_in_directory(base_dir, companion.path, verbose):
-            if verbose:
-                print(f"  Missing companion matching pattern: {companion.path.pattern}")
+            _LOGGER.debug(
+                "  Missing companion matching pattern: %s", companion.path.pattern
+            )
             return ScanIssue(
                 severity="error",
                 code="missing_companion",

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -1,5 +1,6 @@
 """Common library code for repo_structure."""
 
+import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -8,6 +9,8 @@ from pathlib import Path
 from typing import Callable, Final, Literal
 
 BUILTIN_DIRECTORY_RULES: Final = ["ignore"]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ConfigurationParseError(Exception):
@@ -224,8 +227,7 @@ def skip_entry(
 
     for condition in skip_conditions:
         if condition:
-            if flags.verbose:
-                print(f"Skipping {entry.path}")
+            _LOGGER.debug("Skipping %s", entry.path)
             return True
 
     return False
@@ -244,13 +246,12 @@ def to_entry(os_entry: DirEntry[str], rel_dir: str) -> Entry:
 def expand_use_rule(
     use_rule: str,
     structure_rules: StructureRuleMap,
-    flags: Flags,
+    flags: Flags,  # pylint: disable=unused-argument
     rel_path: str,
 ):
     """Expand the use_rule into a list of RepoEntry items."""
     if use_rule:
-        if flags.verbose:
-            print(f"use_rule found for rel path '{rel_path}'")
+        _LOGGER.debug("use_rule found for rel path '%s'", rel_path)
         return _build_active_entry_backlog(
             [use_rule],
             structure_rules,
@@ -258,11 +259,12 @@ def expand_use_rule(
     return None
 
 
-def expand_if_exists(backlog_entry: RepoEntry, flags: Flags):
+def expand_if_exists(
+    backlog_entry: RepoEntry, flags: Flags
+):  # pylint: disable=unused-argument
     """Expand to the entry in `if_exists` or None."""
     if backlog_entry.if_exists:
-        if flags.verbose:
-            print(f"if_exists found for rel path '{backlog_entry.path.pattern}'")
+        _LOGGER.debug("if_exists found for rel path '%s'", backlog_entry.path.pattern)
         return backlog_entry.if_exists
     # the following line can not be reached given a directory entry must be
     # either `use_rule`, or `if_exists`
@@ -350,7 +352,7 @@ def get_matching_item_index(
     backlog: StructureRuleList,
     entry_path: str,
     is_dir: bool,
-    verbose: bool = False,
+    verbose: bool = False,  # pylint: disable=unused-argument
 ) -> MatchResult:
     """Get matching item index without raising exceptions, return result with potential issues."""
     for i, v in enumerate(backlog):
@@ -365,8 +367,7 @@ def get_matching_item_index(
                         path=entry_path,
                     ),
                 )
-            if verbose:
-                print(f"  Found match at index {i}: '{v.path.pattern}'")
+            _LOGGER.debug("  Found match at index %d: '%s'", i, v.path.pattern)
             return MatchResult(success=True, index=i)
 
     display_path = entry_path + "/" if is_dir else entry_path
@@ -382,7 +383,9 @@ def get_matching_item_index(
 
 
 def _find_matching_file_in_directory(
-    base_dir: str, pattern: re.Pattern, verbose: bool
+    base_dir: str,
+    pattern: re.Pattern,
+    verbose: bool,  # pylint: disable=unused-argument
 ) -> bool:
     """Find a file matching the pattern in the directory tree.
 
@@ -405,8 +408,7 @@ def _find_matching_file_in_directory(
             file_rel_normalized = normalize_path(str(file_rel))
 
             if pattern.fullmatch(file_rel_normalized):
-                if verbose:
-                    print(f"  Found companion: {file_rel_normalized}")
+                _LOGGER.debug("  Found companion: %s", file_rel_normalized)
                 return True
 
     return False
@@ -451,8 +453,9 @@ def check_companion_files(
 
         # Search for file matching the companion pattern
         if not _find_matching_file_in_directory(base_dir, companion.path, verbose):
-            if verbose:
-                print(f"  Missing companion matching pattern: {companion.path.pattern}")
+            _LOGGER.debug(
+                "  Missing companion matching pattern: %s", companion.path.pattern
+            )
             return ScanIssue(
                 severity="error",
                 code="missing_companion",

--- a/repo_structure/repo_structure_lib_test.py
+++ b/repo_structure/repo_structure_lib_test.py
@@ -285,7 +285,7 @@ class TestGetMatchingItemIndex:
         result = get_matching_item_index(backlog, "subdir", True)
         assert result == MatchSuccess(index=0)
 
-    def test_get_matching_item_index_verbose_output(self, capsys):
+    def test_get_matching_item_index_verbose_output(self, caplog):
         """Test verbose output when finding a match."""
         backlog = [
             RepoEntry(
@@ -296,9 +296,9 @@ class TestGetMatchingItemIndex:
             )
         ]
 
-        get_matching_item_index(backlog, "file.txt", False, verbose=True)
-        captured = capsys.readouterr()
-        assert "Found match at index 0: 'file\\.txt'" in captured.out
+        with caplog.at_level("DEBUG", logger="repo_structure.repo_structure_lib"):
+            get_matching_item_index(backlog, "file.txt", False, verbose=True)
+        assert "Found match at index 0: 'file\\.txt'" in caplog.text
 
 
 class TestHandleUseRule:
@@ -331,14 +331,14 @@ class TestHandleUseRule:
         result = expand_use_rule("", structure_rules, flags, "app")
         assert result is None
 
-    def test_handle_use_rule_verbose_output(self, capsys):
+    def test_handle_use_rule_verbose_output(self, caplog):
         """Test verbose output when use_rule is found."""
         structure_rules = {"test_rule": []}
         flags = Flags(verbose=True)
 
-        expand_use_rule("test_rule", structure_rules, flags, "app")
-        captured = capsys.readouterr()
-        assert "use_rule found for rel path 'app'" in captured.out
+        with caplog.at_level("DEBUG", logger="repo_structure.repo_structure_lib"):
+            expand_use_rule("test_rule", structure_rules, flags, "app")
+        assert "use_rule found for rel path 'app'" in caplog.text
 
 
 class TestHandleIfExists:
@@ -376,7 +376,7 @@ class TestHandleIfExists:
         result = expand_if_exists(backlog_entry, flags)
         assert result is None
 
-    def test_handle_if_exists_verbose_output(self, capsys):
+    def test_handle_if_exists_verbose_output(self, caplog):
         """Test verbose output when if_exists is found."""
         if_exists_entries = [
             RepoEntry(
@@ -395,9 +395,9 @@ class TestHandleIfExists:
         )
         flags = Flags(verbose=True)
 
-        expand_if_exists(backlog_entry, flags)
-        captured = capsys.readouterr()
-        assert "if_exists found for rel path 'test_pattern'" in captured.out
+        with caplog.at_level("DEBUG", logger="repo_structure.repo_structure_lib"):
+            expand_if_exists(backlog_entry, flags)
+        assert "if_exists found for rel path 'test_pattern'" in caplog.text
 
 
 class TestBuildActiveEntryBacklog:

--- a/repo_structure/repo_structure_lib_test.py
+++ b/repo_structure/repo_structure_lib_test.py
@@ -285,7 +285,7 @@ class TestGetMatchingItemIndex:
         result = get_matching_item_index(backlog, "subdir", True)
         assert result == MatchResult(success=True, index=0, issue=None)
 
-    def test_get_matching_item_index_verbose_output(self, capsys):
+    def test_get_matching_item_index_verbose_output(self, caplog):
         """Test verbose output when finding a match."""
         backlog = [
             RepoEntry(
@@ -296,9 +296,9 @@ class TestGetMatchingItemIndex:
             )
         ]
 
-        get_matching_item_index(backlog, "file.txt", False, verbose=True)
-        captured = capsys.readouterr()
-        assert "Found match at index 0: 'file\\.txt'" in captured.out
+        with caplog.at_level("DEBUG", logger="repo_structure.repo_structure_lib"):
+            get_matching_item_index(backlog, "file.txt", False, verbose=True)
+        assert "Found match at index 0: 'file\\.txt'" in caplog.text
 
 
 class TestHandleUseRule:
@@ -331,14 +331,14 @@ class TestHandleUseRule:
         result = expand_use_rule("", structure_rules, flags, "app")
         assert result is None
 
-    def test_handle_use_rule_verbose_output(self, capsys):
+    def test_handle_use_rule_verbose_output(self, caplog):
         """Test verbose output when use_rule is found."""
         structure_rules = {"test_rule": []}
         flags = Flags(verbose=True)
 
-        expand_use_rule("test_rule", structure_rules, flags, "app")
-        captured = capsys.readouterr()
-        assert "use_rule found for rel path 'app'" in captured.out
+        with caplog.at_level("DEBUG", logger="repo_structure.repo_structure_lib"):
+            expand_use_rule("test_rule", structure_rules, flags, "app")
+        assert "use_rule found for rel path 'app'" in caplog.text
 
 
 class TestHandleIfExists:
@@ -376,7 +376,7 @@ class TestHandleIfExists:
         result = expand_if_exists(backlog_entry, flags)
         assert result is None
 
-    def test_handle_if_exists_verbose_output(self, capsys):
+    def test_handle_if_exists_verbose_output(self, caplog):
         """Test verbose output when if_exists is found."""
         if_exists_entries = [
             RepoEntry(
@@ -395,9 +395,9 @@ class TestHandleIfExists:
         )
         flags = Flags(verbose=True)
 
-        expand_if_exists(backlog_entry, flags)
-        captured = capsys.readouterr()
-        assert "if_exists found for rel path 'test_pattern'" in captured.out
+        with caplog.at_level("DEBUG", logger="repo_structure.repo_structure_lib"):
+            expand_if_exists(backlog_entry, flags)
+        assert "if_exists found for rel path 'test_pattern'" in caplog.text
 
 
 class TestBuildActiveEntryBacklog:


### PR DESCRIPTION
## Summary

- Add a per-module logger and replace verbose `print` / `pprint` calls with `_LOGGER.debug` in `repo_structure_lib`, `repo_structure_config`, `repo_structure_full_scan`, `repo_structure_diff_scan`.
- Drop the unconditional `pprint.pprint` debug output from `Configuration.__init__`.
- In `__main__.py`, the `-v / --verbose` flag now calls `logging.basicConfig(level=DEBUG, stream=stdout)` so the CLI verbose UX is preserved.
- Three tests that captured stdout via `capsys` now use `caplog`.

Closes #170

## Test plan

- [x] \`uv run --extra dev pytest -q\` — 185 passed
- [x] \`uv run --extra dev pylint repo_structure/*.py\` — 10.00/10
- [x] Pre-commit hooks (black, mypy, ruff) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)