### PR TITLE
Phase 2.3: Drop redundant iter(), inline _max_values_length

### DIFF
--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -336,16 +336,12 @@ def _parse_use_template(
         return
 
     def _expand_template(dir_map_yaml, templates_yaml):
-
-        def _max_values_length(expansion_map: dict[str, list[str]]) -> int:
-            max_length = 0
-            for _, values in expansion_map.items():
-                max_length = max(max_length, len(values))
-            return max_length
-
         expansion_map = dir_map_yaml["parameters"]
+        max_values_length = max(
+            (len(values) for values in expansion_map.values()), default=0
+        )
         structure_rules_yaml: list[dict] = []
-        for i in range(_max_values_length(expansion_map)):
+        for i in range(max_values_length):
             if dir_map_yaml["use_template"] not in templates_yaml:
                 raise TemplateError(
                     f"Template '{dir_map_yaml['use_template']}'"

--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -345,16 +345,12 @@ def _parse_use_template(
         return
 
     def _expand_template(dir_map_yaml, templates_yaml):
-
-        def _max_values_length(expansion_map: dict[str, list[str]]) -> int:
-            max_length = 0
-            for _, values in expansion_map.items():
-                max_length = max(max_length, len(values))
-            return max_length
-
         expansion_map = dir_map_yaml["parameters"]
+        max_values_length = max(
+            (len(values) for values in expansion_map.values()), default=0
+        )
         structure_rules_yaml: list[dict] = []
-        for i in range(_max_values_length(expansion_map)):
+        for i in range(max_values_length):
             if dir_map_yaml["use_template"] not in templates_yaml:
                 raise TemplateError(
                     f"Template '{dir_map_yaml['use_template']}'"

--- a/repo_structure/repo_structure_test_lib.py
+++ b/repo_structure/repo_structure_test_lib.py
@@ -29,7 +29,7 @@ def _create_repo_directory_structure(specification: str) -> None:
     | <dirname>/                 | Directory                                                       |
     | <linkname> -> <targetfile> | Symbolic link with the name <linkname> pointing to <targetfile> |
     """
-    for item in iter(specification.splitlines()):
+    for item in specification.splitlines():
         if item.startswith("#") or item.strip() == "":
             continue
         if item.strip().endswith("/"):


### PR DESCRIPTION
## Summary

- Remove the redundant \`iter()\` wrap around \`splitlines()\` in the test fixture loop.
- Inline the manual \`_max_values_length\` helper as \`max((len(v) for v in expansion_map.values()), default=0)\`.

Closes #172

## Test plan

- [x] \`uv run --extra dev pytest -q\` — 185 passed
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)