### PR TITLE
Phase 2.5: Reference BUILTIN_DIRECTORY_RULES constant

### DIFF
--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -12,6 +12,7 @@ from .repo_structure_config import (
 )
 
 from .repo_structure_lib import (
+    BUILTIN_DIRECTORY_RULES,
     map_dir_to_rel_dir,
     skip_entry,
     to_entry,
@@ -245,7 +246,7 @@ class FullScanProcessor:
         used_rules = set()
         for rules in self.config.directory_map.values():
             for r in rules:
-                if r and r not in ("ignore",):
+                if r and r not in BUILTIN_DIRECTORY_RULES:
                     used_rules.add(r)
 
         for rule_name in self.config.structure_rules.keys():

--- a/repo_structure/repo_structure_full_scan.py
+++ b/repo_structure/repo_structure_full_scan.py
@@ -11,6 +11,7 @@ from .repo_structure_config import (
 )
 
 from .repo_structure_lib import (
+    BUILTIN_DIRECTORY_RULES,
     map_dir_to_rel_dir,
     skip_entry,
     to_entry,
@@ -234,7 +235,7 @@ class FullScanProcessor:
         used_rules = set()
         for rules in self.config.directory_map.values():
             for r in rules:
-                if r and r not in ("ignore",):
+                if r and r not in BUILTIN_DIRECTORY_RULES:
                     used_rules.add(r)
 
         for rule_name in self.config.structure_rules.keys():

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -8,7 +8,8 @@ from os import DirEntry
 from pathlib import Path
 from typing import Callable, Final, Literal
 
-BUILTIN_DIRECTORY_RULES: Final = ["ignore"]
+IGNORE_RULE: Final = "ignore"
+BUILTIN_DIRECTORY_RULES: Final = (IGNORE_RULE,)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -327,7 +328,7 @@ def _build_active_entry_backlog(
 ) -> StructureRuleList:
     result: StructureRuleList = []
     for rule in active_use_rules:
-        if rule == "ignore":
+        if rule in BUILTIN_DIRECTORY_RULES:
             continue
         rules = structure_rules[rule]
         # Clone every entry so scan-time mutations (count += 1) do not leak

--- a/repo_structure/repo_structure_lib.py
+++ b/repo_structure/repo_structure_lib.py
@@ -7,7 +7,8 @@ from os import DirEntry
 from pathlib import Path
 from typing import Callable, Final, Literal
 
-BUILTIN_DIRECTORY_RULES: Final = ["ignore"]
+IGNORE_RULE: Final = "ignore"
+BUILTIN_DIRECTORY_RULES: Final = (IGNORE_RULE,)
 
 
 class ConfigurationParseError(Exception):
@@ -296,7 +297,7 @@ def _build_active_entry_backlog(
 ) -> StructureRuleList:
     result: StructureRuleList = []
     for rule in active_use_rules:
-        if rule == "ignore":
+        if rule in BUILTIN_DIRECTORY_RULES:
             continue
         rules = structure_rules[rule]
         result += rules

--- a/repo_structure/repo_structure_report.py
+++ b/repo_structure/repo_structure_report.py
@@ -6,7 +6,12 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Literal
 from .repo_structure_config import Configuration
-from .repo_structure_lib import DirectoryMap, StructureRuleMap
+from .repo_structure_lib import (
+    BUILTIN_DIRECTORY_RULES,
+    DirectoryMap,
+    IGNORE_RULE,
+    StructureRuleMap,
+)
 
 
 @dataclass
@@ -151,7 +156,7 @@ def _generate_directory_reports(
     for directory, rules in directory_map.items():
         rule_descriptions = []
         for rule in rules:
-            if rule == "ignore":
+            if rule in BUILTIN_DIRECTORY_RULES:
                 rule_descriptions.append(
                     "Builtin rule: Excludes this directory from structure validation"
                 )
@@ -218,12 +223,12 @@ def _generate_structure_rule_reports(
 
     reports = []
 
-    # Check if 'ignore' rule is used anywhere
+    # Check if the ignore rule is used anywhere
     ignore_directories = [
-        directory for directory, rules in directory_map.items() if "ignore" in rules
+        directory for directory, rules in directory_map.items() if IGNORE_RULE in rules
     ]
 
-    # Add built-in 'ignore' rule if it's used
+    # Add built-in ignore rule if it's used
     if ignore_directories:
         directory_descs = [
             directory_descriptions.get(directory, "No description provided")
@@ -231,7 +236,7 @@ def _generate_structure_rule_reports(
         ]
         reports.append(
             StructureRuleReport(
-                rule_name="ignore",
+                rule_name=IGNORE_RULE,
                 description="Builtin rule: Excludes this directory from structure validation",
                 applied_directories=ignore_directories,
                 directory_descriptions=directory_descs,

--- a/repo_structure/repo_structure_report.py
+++ b/repo_structure/repo_structure_report.py
@@ -6,7 +6,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Any, Optional
 from .repo_structure_config import Configuration
-from .repo_structure_lib import DirectoryMap, StructureRuleMap
+from .repo_structure_lib import (
+    BUILTIN_DIRECTORY_RULES,
+    DirectoryMap,
+    IGNORE_RULE,
+    StructureRuleMap,
+)
 
 
 @dataclass
@@ -151,7 +156,7 @@ def _generate_directory_reports(
     for directory, rules in directory_map.items():
         rule_descriptions = []
         for rule in rules:
-            if rule == "ignore":
+            if rule in BUILTIN_DIRECTORY_RULES:
                 rule_descriptions.append(
                     "Builtin rule: Excludes this directory from structure validation"
                 )
@@ -218,12 +223,12 @@ def _generate_structure_rule_reports(
 
     reports = []
 
-    # Check if 'ignore' rule is used anywhere
+    # Check if the ignore rule is used anywhere
     ignore_directories = [
-        directory for directory, rules in directory_map.items() if "ignore" in rules
+        directory for directory, rules in directory_map.items() if IGNORE_RULE in rules
     ]
 
-    # Add built-in 'ignore' rule if it's used
+    # Add built-in ignore rule if it's used
     if ignore_directories:
         directory_descs = [
             directory_descriptions.get(directory, "No description provided")
@@ -231,7 +236,7 @@ def _generate_structure_rule_reports(
         ]
         reports.append(
             StructureRuleReport(
-                rule_name="ignore",
+                rule_name=IGNORE_RULE,
                 description="Builtin rule: Excludes this directory from structure validation",
                 applied_directories=ignore_directories,
                 directory_descriptions=directory_descs,


### PR DESCRIPTION
## Summary

- Introduce an \`IGNORE_RULE\` constant; redefine \`BUILTIN_DIRECTORY_RULES\` as a tuple containing it.
- Replace literal \`\"ignore\"\` usages across the scanner and report modules with either \`BUILTIN_DIRECTORY_RULES\` membership checks or the \`IGNORE_RULE\` constant.

Closes #174

## Test plan

- [x] \`uv run --extra dev pytest -q\` — 185 passed
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)