### PR TITLE
Phase 2.6: Add --output-format as canonical option

### DIFF
--- a/repo_structure/__main__.py
+++ b/repo_structure/__main__.py
@@ -298,8 +298,10 @@ def diff_scan(ctx: click.Context, config_path: str, paths: list[str]) -> None:
     show_default=True,
 )
 @click.option(
+    "--output-format",
     "--output_format",
     "-f",
+    "output_format",
     type=click.Choice(["text", "json", "markdown"]),
     help="Output format for the report.",
     default="text",

--- a/repo_structure/__main__.py
+++ b/repo_structure/__main__.py
@@ -291,8 +291,10 @@ def diff_scan(ctx: click.Context, config_path: str, paths: list[str]) -> None:
     show_default=True,
 )
 @click.option(
+    "--output-format",
     "--output_format",
     "-f",
+    "output_format",
     type=click.Choice(["text", "json", "markdown"]),
     help="Output format for the report.",
     default="text",


### PR DESCRIPTION
## Summary

Make \`--output-format\` (dash-separated, matching the convention used by the rest of the CLI) the canonical name for the report format option. \`--output_format\` remains accepted for backwards compatibility.

Closes #175

## Test plan

- [x] \`uv run --extra dev pytest -q\` — 185 passed
- [x] \`uv run repo_structure report --help\` shows both names
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)