### PR TITLE
fix: correct typo 'strucgure' → 'structure'

### DIFF
--- a/repo_structure/__init__.py
+++ b/repo_structure/__init__.py
@@ -1,4 +1,4 @@
-"""Check the repository directory strucgure against your configuration."""
+"""Check the repository directory structure against your configuration."""
 
 from .repo_structure_config import Configuration
 from .repo_structure_full_scan import FullScanProcessor


### PR DESCRIPTION
Fixes typo in `repo_structure/__init__.py`.

`strucgure` → `structure`

Closes #169