### PR TITLE
Replace pre-commit action with prek

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -1,4 +1,4 @@
-name: Pre-Commit
+name: Prek
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
     branches:
       - main
 jobs:
-  pre-commit:
+  prek:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -19,4 +19,4 @@ jobs:
         run: pip install uv
       - name: Install development dependencies
         run: pip install -e .[dev]
-      - uses: pre-commit/action@v3.0.1
+      - uses: j178/prek-action@v2.0.6


### PR DESCRIPTION
## Summary

Replaces `pre-commit/action@v3.0.1` with [`j178/prek-action@v2.0.6`](https://github.com/j178/prek-action) in the CI workflow.

[prek](https://github.com/j178/prek) is a drop-in Rust reimplementation of pre-commit that reads the same config format, so `.pre-commit-config.yaml` is **unchanged** and all hooks run as before.

## Changes

`.github/workflows/pre-commit.yml` → `.github/workflows/prek.yml`:

- `name: Pre-Commit` → `name: Prek`
- job `pre-commit` → `prek`
- `pre-commit/action@v3.0.1` → `j178/prek-action@v2.0.6`

The `setup-python` and `uv` install steps are intentionally kept: the `local` hooks (`repo-structure-diff`, `pylint-uv`) use `language: system` and shell out to `uv run`.

## Testing

Ran `prek run --all-files` locally — all 13 hooks pass.

## Note for the reviewer

⚠️ The required status check name changes from `pre-commit` to `prek`. If `pre-commit` is listed as a required check in the branch protection ruleset for `main`, this PR will block until the ruleset is updated.

Renovate is unaffected: `prek-action` is pinned to a patch tag so the `github-actions` manager keeps updating it, and hook `rev`s in `.pre-commit-config.yaml` are handled by the separate `pre-commit` manager, which keys off the config file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)