### PR TITLE
Phase 3.3: Add Configuration mutation methods

### DIFF
--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -231,6 +231,19 @@ class Configuration:
                         f"Directory mapping '{directory}' uses non-existing rule '{r}'"
                     )
 
+    def add_template_rule(
+        self, directory: str, rule_name: str, entries: StructureRuleList
+    ) -> None:
+        """Register an expanded template rule and map it to a directory.
+
+        Args:
+            directory: Directory map key the expanded rule applies to.
+            rule_name: Name to register the generated structure rule under.
+            entries: Parsed entries making up the generated structure rule.
+        """
+        self.config.structure_rules[rule_name] = entries
+        self.config.directory_map.setdefault(directory, []).append(rule_name)
+
     @property
     def structure_rules(self) -> StructureRuleMap:
         """Property for structure rules."""
@@ -462,8 +475,7 @@ def _parse_use_template(
         f"__template_rule_{map_dir_to_rel_dir(directory)}_"
         f"{dir_map_yaml['use_template']}"
     )
-    config.config.structure_rules[template_rule_name] = structure_rule_list
-    config.config.directory_map[directory].append(template_rule_name)
+    config.add_template_rule(directory, template_rule_name, structure_rule_list)
 
 
 def _build_directory_map(

--- a/repo_structure/repo_structure_config_test.py
+++ b/repo_structure/repo_structure_config_test.py
@@ -580,3 +580,49 @@ directory_map:
     companion = cpp_rule.companion[0]
     assert companion.path.pattern == "{{base}}.h"
     assert companion.is_required
+
+
+def test_template_expansion_registers_rule_in_directory_map():
+    """Test that expanding a template registers the generated rule."""
+    test_yaml = r"""
+templates:
+  component:
+    - description: 'Component template'
+    - require: '{{name}}.cpp'
+directory_map:
+  /components/:
+    - description: 'Components directory'
+    - use_template: component
+      parameters:
+        name: ['lidar', 'camera']
+"""
+    config = Configuration.from_yaml_string(test_yaml)
+
+    rule_name = "__template_rule_components_component"
+    assert rule_name in config.structure_rules
+    assert config.directory_map["/components/"] == [rule_name]
+    assert [e.path.pattern for e in config.structure_rules[rule_name]] == [
+        "lidar.cpp",
+        "camera.cpp",
+    ]
+
+
+def test_add_template_rule_creates_missing_directory_entry():
+    """Test that add_template_rule works for a directory without prior rules."""
+    test_yaml = r"""
+structure_rules:
+  basic_rule:
+    - description: 'Basic rule'
+    - require: 'README\.md'
+directory_map:
+  /:
+    - description: 'Root directory'
+    - use_rule: basic_rule
+"""
+    config = Configuration.from_yaml_string(test_yaml)
+    entries = config.structure_rules["basic_rule"]
+
+    config.add_template_rule("/new_dir/", "__template_rule_new", entries)
+
+    assert config.structure_rules["__template_rule_new"] is entries
+    assert config.directory_map["/new_dir/"] == ["__template_rule_new"]


### PR DESCRIPTION
## Problem

`_parse_use_template` wrote directly into `config.config.structure_rules` and `config.config.directory_map` from outside the class, leaking the internal `ConfigurationData` dataclass through the API.

## Fix

Add `Configuration.add_template_rule(directory, rule_name, entries)` and route template expansion through it. The method uses `setdefault` on the directory map, so a directory with a `use_template` but no `use_rule` entries no longer depends on `_build_directory_map` having pre-created the list.

## Tests

- `test_template_expansion_registers_rule_in_directory_map` — end-to-end check that expansion registers the generated rule under the expected name and maps it to the directory.
- `test_add_template_rule_creates_missing_directory_entry` — the method creates the directory map entry when absent.

187 tests pass; pylint 10.00/10; pre-commit (mypy, black, pylint, ruff) clean.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)