### PR TITLE
Phase 3.4: Collapse _get_pattern / _get_pattern_key / _get_is_required

### DIFF
--- a/repo_structure/repo_structure_config.py
+++ b/repo_structure/repo_structure_config.py
@@ -5,7 +5,7 @@ import logging
 import re
 import warnings
 from dataclasses import dataclass, field
-from typing import TextIO, Any
+from typing import NamedTuple, TextIO, Any
 
 from ruamel import yaml as YAML
 from jsonschema import validate, ValidationError, SchemaError
@@ -351,27 +351,39 @@ def _build_rules(
     return rules, descriptions
 
 
-def _get_pattern(entry: dict) -> str:
-    if "require" in entry:
-        return entry["require"]
-    if "allow" in entry:
-        return entry["allow"]
-    # if "forbid" in entry:
-    return entry["forbid"]
+# The keys that carry an entry's pattern, in precedence order - the first
+# one present on an entry decides how the entry is treated.
+_PATTERN_KEYS = ("require", "allow", "forbid")
 
 
-def _get_is_required(entry: dict) -> bool:
-    if "allow" in entry:
-        return False
-    if "forbid" in entry:
-        return False
-    # if "require" in entry:
-    return True
+class ParsedEntry(NamedTuple):
+    """A structure rule entry's pattern together with how it is enforced."""
+
+    pattern: str
+    kind: str
+    is_required: bool
+
+    @property
+    def is_forbidden(self) -> bool:
+        """True if the entry's pattern must not match anything."""
+        return self.kind == "forbid"
+
+
+def _classify_entry(entry: dict) -> ParsedEntry:
+    """Determine which pattern key an entry uses and what it implies."""
+    for kind in _PATTERN_KEYS:
+        if kind in entry:
+            return ParsedEntry(
+                pattern=entry[kind], kind=kind, is_required=kind == "require"
+            )
+    raise ConfigurationParseError(
+        f"Entry must contain one of {', '.join(_PATTERN_KEYS)}: {entry}"
+    )
 
 
 def _parse_entry_to_repo_entry(entry: dict) -> RepoEntry:
-    entry_pattern = _get_pattern(entry)
-    is_required = _get_is_required(entry)
+    parsed = _classify_entry(entry)
+    entry_pattern = parsed.pattern
 
     is_dir = entry_pattern.endswith("/")
     entry_pattern = entry_pattern[0:-1] if is_dir else entry_pattern
@@ -386,8 +398,8 @@ def _parse_entry_to_repo_entry(entry: dict) -> RepoEntry:
     result = RepoEntry(
         path=compiled_pattern,
         is_dir=is_dir,
-        is_required=is_required,
-        is_forbidden="forbid" in entry,
+        is_required=parsed.is_required,
+        is_forbidden=parsed.is_forbidden,
         use_rule=entry.get("use_rule", ""),
     )
     for sub_entry in entry.get("if_exists", []):
@@ -399,15 +411,6 @@ def _parse_entry_to_repo_entry(entry: dict) -> RepoEntry:
     return result
 
 
-def _get_pattern_key(entry: dict) -> str:
-    if "require" in entry:
-        return "require"
-    if "allow" in entry:
-        return "allow"
-    # if "forbid" in entry:
-    return "forbid"
-
-
 def _expand_template_entry(
     template_yaml: list[dict], expansion_key: str, expansion_var: str
 ) -> list[dict]:
@@ -416,7 +419,7 @@ def _expand_template_entry(
         # Skip description entries
         if "description" in entry and len(entry) == 1:
             return entry
-        k = _get_pattern_key(entry)
+        k = _classify_entry(entry).kind
         entry[k] = entry[k].replace(f"{{{{{expansion_key}}}}}", expansion_var)
         return entry
 

--- a/repo_structure/repo_structure_config_test.py
+++ b/repo_structure/repo_structure_config_test.py
@@ -3,6 +3,7 @@
 import pytest
 from .repo_structure_config import (
     Configuration,
+    _classify_entry,
 )
 from . import ConfigurationParseError
 from .repo_structure_lib import StructureRuleError, TemplateError
@@ -626,3 +627,83 @@ directory_map:
 
     assert config.structure_rules["__template_rule_new"] is entries
     assert config.directory_map["/new_dir/"] == ["__template_rule_new"]
+
+
+@pytest.mark.parametrize(
+    "entry, kind, is_required, is_forbidden",
+    [
+        ({"require": r"README\.md"}, "require", True, False),
+        ({"allow": r".*\.md"}, "allow", False, False),
+        ({"forbid": r".*\.tmp"}, "forbid", False, True),
+    ],
+)
+def test_classify_entry(entry, kind, is_required, is_forbidden):
+    """Test that each pattern key maps to the expected classification."""
+    parsed = _classify_entry(entry)
+
+    assert parsed.pattern == entry[kind]
+    assert parsed.kind == kind
+    assert parsed.is_required == is_required
+    assert parsed.is_forbidden == is_forbidden
+
+
+def test_classify_entry_precedence():
+    """Test that require wins over allow, and allow over forbid."""
+    assert _classify_entry({"allow": "a", "require": "r"}).kind == "require"
+    assert _classify_entry({"forbid": "f", "allow": "a"}).kind == "allow"
+
+
+def test_classify_entry_without_pattern_key():
+    """Test that an entry lacking any pattern key is reported clearly."""
+    with pytest.raises(ConfigurationParseError) as exc_info:
+        _classify_entry({"use_rule": "some_rule"})
+
+    assert "require, allow, forbid" in str(exc_info.value)
+
+
+def test_forbid_entry_is_not_required():
+    """Test that a forbidden entry is parsed as forbidden and not required."""
+    test_yaml = r"""
+structure_rules:
+  basic_rule:
+    - description: 'Basic rule'
+    - require: 'README\.md'
+    - allow: '.*\.md'
+    - forbid: '.*\.tmp'
+directory_map:
+  /:
+    - description: 'Root directory'
+    - use_rule: basic_rule
+"""
+    config = Configuration.from_yaml_string(test_yaml)
+    entries = {e.path.pattern: e for e in config.structure_rules["basic_rule"]}
+
+    assert entries[r"README\.md"].is_required
+    assert not entries[r"README\.md"].is_forbidden
+    assert not entries[r".*\.md"].is_required
+    assert not entries[r".*\.md"].is_forbidden
+    assert not entries[r".*\.tmp"].is_required
+    assert entries[r".*\.tmp"].is_forbidden
+
+
+def test_template_expansion_of_allow_and_forbid_entries():
+    """Test that template expansion substitutes allow and forbid patterns."""
+    test_yaml = r"""
+templates:
+  component:
+    - description: 'Component template'
+    - allow: '{{name}}\.md'
+    - forbid: '{{name}}\.tmp'
+directory_map:
+  /components/:
+    - description: 'Components directory'
+    - use_template: component
+      parameters:
+        name: ['lidar']
+"""
+    config = Configuration.from_yaml_string(test_yaml)
+    entries = config.structure_rules["__template_rule_components_component"]
+
+    assert [e.path.pattern for e in entries] == [r"lidar\.md", r"lidar\.tmp"]
+    assert not entries[0].is_forbidden
+    assert entries[1].is_forbidden


### PR DESCRIPTION
## Summary

Closes #179.

`repo_structure_config.py` had three parallel helpers — `_get_pattern`, `_get_is_required`, and `_get_pattern_key` — each branching over the same `require` / `allow` / `forbid` keys, each ending in a stale commented-out `# if "forbid" in entry:` line.

They are replaced by a single `_classify_entry()` returning a `ParsedEntry` named tuple with `pattern`, `kind`, and `is_required` (plus an `is_forbidden` property derived from `kind`). The key set now lives in one place, `_PATTERN_KEYS`, which also defines the precedence order.

## Behavior notes

- An entry carrying none of the three keys now raises `ConfigurationParseError` with a clear message instead of `KeyError`. The JSON schema already rejects such entries, so this only affects direct helper calls.
- An entry carrying *both* `require` and `forbid` previously came out as `is_required=True` **and** `is_forbidden=True`, because `is_forbidden` was computed independently as `"forbid" in entry`. Both flags now follow the same precedence, so the first key present wins.

## Tests

Adds coverage for the classifier (each kind, precedence, missing-key error), for `require`/`allow`/`forbid` round-tripping through config parsing, and for template expansion of `allow`/`forbid` patterns — the `_get_pattern_key` path that had no direct test.

`prek run --from-ref main --to-ref HEAD`: all hooks pass. Full suite: 194 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)