### PR TITLE
Phase 5.1: Introduce ScanResult wrapper

### DIFF
--- a/repo_structure/__init__.py
+++ b/repo_structure/__init__.py
@@ -7,6 +7,7 @@ from .errors import ConfigurationParseError
 from .models import (
     Flags,
     ScanIssue,
+    ScanResult,
     MatchResult,
     MatchSuccess,
     MatchFailure,
@@ -18,6 +19,7 @@ __all__ = [
     "FullScanProcessor",
     "DiffScanProcessor",
     "ScanIssue",
+    "ScanResult",
     "MatchResult",
     "MatchSuccess",
     "MatchFailure",

--- a/repo_structure/__main__.py
+++ b/repo_structure/__main__.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import click
 
 from .errors import ConfigurationParseError
-from .models import Flags, ScanIssue
+from .models import Flags, ScanResult
 from .full_scan import (
     FullScanProcessor,
 )
@@ -98,39 +98,35 @@ def _validate_directory_mapping(directory: str, config: Configuration) -> None:
 
 def _perform_scan(
     repo_root: str, config: Configuration, flags: Flags, directory: str | None
-) -> tuple[list[ScanIssue], list[ScanIssue]]:
+) -> ScanResult:
     """Perform the actual scan operation."""
+    processor = FullScanProcessor(repo_root, config, flags)
+
     if directory:
         directory = f'/{directory.strip("/")}/'
         _validate_directory_mapping(directory, config)
-        processor = FullScanProcessor(repo_root, config, flags)
-        errors = processor.scan_directory(directory)
-        return errors, []
+        return processor.scan_directory(directory)
 
-    processor = FullScanProcessor(repo_root, config, flags)
     return processor.scan()
 
 
-def _print_scan_results(errors: list[ScanIssue], warnings: list[ScanIssue]) -> bool:
+def _print_scan_results(result: ScanResult) -> bool:
     """Print scan results and return success status."""
-    successful = True
-
     # Print warnings first
-    if warnings:
+    if result.warnings:
         click.echo(click.style("Warnings:", fg="yellow"))
-        for w in warnings:
+        for w in result.warnings:
             loc = f" [{w.path}]" if getattr(w, "path", None) else ""
             click.echo(click.style(f" - ({w.code}) {w.message}{loc}", fg="yellow"))
 
     # Then errors
-    if errors:
+    if result.errors:
         click.echo(click.style("Errors:", fg="red"))
-        for e in errors:
+        for e in result.errors:
             loc = f" [{e.path}]" if getattr(e, "path", None) else ""
             click.echo(click.style(f" - ({e.code}) {e.message}{loc}", fg="red"))
-        successful = False
 
-    return successful
+    return result.is_success
 
 
 @repo_structure.command()
@@ -186,8 +182,8 @@ def full_scan(
     start_time = time.time()
 
     config = _load_configuration(config_path, flags.verbose)
-    errors, warnings = _perform_scan(repo_root, config, flags, directory)
-    successful = _print_scan_results(errors, warnings)
+    result = _perform_scan(repo_root, config, flags, directory)
+    successful = _print_scan_results(result)
 
     duration = time.time() - start_time
     if flags.verbose:
@@ -257,16 +253,14 @@ def diff_scan(ctx: click.Context, config_path: str, paths: list[str]) -> None:
             valid_paths.append(path)
 
     # Check all valid paths efficiently
-    issues = processor.check_paths(valid_paths)
-    if issues:
-        for issue in issues:
-            loc = f" [{issue.path}]" if getattr(issue, "path", None) else ""
-            click.echo(
-                "Error: "
-                + click.style(f"({issue.code}) {issue.message}{loc}", fg="red"),
-                err=True,
-            )
-        successful = False
+    result = processor.check_paths(valid_paths)
+    for issue in result.errors:
+        loc = f" [{issue.path}]" if getattr(issue, "path", None) else ""
+        click.echo(
+            "Error: " + click.style(f"({issue.code}) {issue.message}{loc}", fg="red"),
+            err=True,
+        )
+    successful = successful and result.is_success
 
     click.echo(
         "Checks have"

--- a/repo_structure/diff_scan.py
+++ b/repo_structure/diff_scan.py
@@ -13,6 +13,7 @@ from .models import (
     Flags,
     MatchFailure,
     ScanIssue,
+    ScanResult,
     StructureRuleList,
 )
 from .paths import (
@@ -174,18 +175,19 @@ class DiffScanProcessor:
 
         return issue
 
-    def check_paths(self, paths: list[str]) -> list[ScanIssue]:
+    def check_paths(self, paths: list[str]) -> ScanResult:
         """Check multiple paths efficiently using the same configuration.
 
         Args:
             paths: List of paths to check
 
         Returns:
-            List of ScanIssues for invalid paths. Empty list if all paths are valid.
+            ScanResult holding one error per invalid path. A diff scan cannot
+            detect missing required entries, so warnings are always empty.
         """
-        issues = []
+        errors = []
         for path in paths:
             issue = self.check_path(path)
             if issue:
-                issues.append(issue)
-        return issues
+                errors.append(issue)
+        return ScanResult(errors=errors)

--- a/repo_structure/diff_scan_test.py
+++ b/repo_structure/diff_scan_test.py
@@ -239,8 +239,9 @@ directory_map:
 
     # Test with all valid paths
     valid_paths = ["README.md", "LICENSE"]
-    issues = processor.check_paths(valid_paths)
-    assert len(issues) == 0
+    result = processor.check_paths(valid_paths)
+    assert result.is_success
+    assert len(result.errors) == 0
 
     # Test with mixed valid and invalid paths
     mixed_paths = [
@@ -250,7 +251,9 @@ directory_map:
         "CMakeLists.txt",
         "another_invalid.txt",
     ]
-    issues = processor.check_paths(mixed_paths)
+    result = processor.check_paths(mixed_paths)
+    assert not result.is_success
+    issues = result.errors
     assert len(issues) == 3
 
     # Check specific issues

--- a/repo_structure/full_scan.py
+++ b/repo_structure/full_scan.py
@@ -17,6 +17,7 @@ from .models import (
     Flags,
     MatchFailure,
     ScanIssue,
+    ScanResult,
     StructureRuleList,
 )
 from .paths import join_path_normalized, map_dir_to_rel_dir
@@ -262,21 +263,22 @@ class FullScanProcessor:
                 )
         return warnings
 
-    def scan(self) -> tuple[list[ScanIssue], list[ScanIssue]]:
-        """Scan the repository and return a list of issues (errors and warnings)."""
+    def scan(self) -> ScanResult:
+        """Scan the repository and return the errors and warnings found."""
         errors = self._collect_errors()
         warnings = self._collect_warnings()
         errors.sort(key=lambda x: (x.path is None, x.path or "", x.code))
         warnings.sort(key=lambda x: (x.path is None, x.path or "", x.code))
-        return errors, warnings
+        return ScanResult(errors=errors, warnings=warnings)
 
-    def scan_directory(self, map_dir: str) -> list[ScanIssue]:
-        """Scan a single directory mapping and return issues.
+    def scan_directory(self, map_dir: str) -> ScanResult:
+        """Scan a single directory mapping and return the issues found.
 
         Args:
             map_dir: Directory mapping key (e.g. "/", "src/", "tests/")
 
         Returns:
-            List of scan issues found in the specified directory mapping
+            ScanResult for the specified directory mapping. Warnings are always
+            empty, since unused-rule detection is repository-wide.
         """
-        return self._process_map_dir(map_dir)
+        return ScanResult(errors=self._process_map_dir(map_dir))

--- a/repo_structure/full_scan_test.py
+++ b/repo_structure/full_scan_test.py
@@ -21,7 +21,8 @@ def _check_repo_directory_structure(
 ) -> tuple[list[ScanIssue], list[ScanIssue]]:
     """Check repository structure and return errors and warnings instead of asserting."""
     processor = FullScanProcessor(".", config, flags)
-    return processor.scan()
+    result = processor.scan()
+    return result.errors, result.warnings
 
 
 @with_repo_structure_in_tmpdir("")
@@ -1146,7 +1147,7 @@ directory_map:
     """
     config = Configuration(config_yaml, True)
     processor = FullScanProcessor(".", config, Flags())
-    _, warnings = processor.scan()
+    warnings = processor.scan().warnings
     assert any(
         "unused_rule" in i.message for i in warnings
     ), f"Expected unused rule warning, got: {warnings}"

--- a/repo_structure/models.py
+++ b/repo_structure/models.py
@@ -63,6 +63,23 @@ class ScanIssue:
     path: str | None = None
 
 
+@dataclass
+class ScanResult:
+    """Outcome of a scan: the issues found, split by severity.
+
+    Both processors return this shape so callers do not have to special-case
+    per-processor return types.
+    """
+
+    errors: list[ScanIssue] = field(default_factory=list)
+    warnings: list[ScanIssue] = field(default_factory=list)
+
+    @property
+    def is_success(self) -> bool:
+        """True when the scan found no errors. Warnings do not fail a scan."""
+        return not self.errors
+
+
 @dataclass(frozen=True)
 class MatchSuccess:
     """Successful match: holds the index of the matched backlog entry."""

--- a/repo_structure/models_test.py
+++ b/repo_structure/models_test.py
@@ -13,6 +13,7 @@ from .models import (
     MatchSuccess,
     RepoEntry,
     ScanIssue,
+    ScanResult,
 )
 
 
@@ -84,6 +85,40 @@ class TestScanIssue:
             severity="error", code="forbidden_entry", message="nope", path="a.txt"
         )
         assert issue == same
+
+
+class TestScanResult:
+    """Test the ScanResult dataclass."""
+
+    def test_empty_result_is_successful(self):
+        """Test that a result without issues defaults to empty and successful."""
+        result = ScanResult()
+        assert not result.errors
+        assert not result.warnings
+        assert result.is_success
+
+    def test_errors_fail_the_scan(self):
+        """Test that any error makes the result unsuccessful."""
+        issue = ScanIssue(severity="error", code="unspecified_entry", message="nope")
+        assert not ScanResult(errors=[issue]).is_success
+
+    def test_warnings_alone_do_not_fail_the_scan(self):
+        """Test that warnings are reported without failing the scan."""
+        warning = ScanIssue(
+            severity="warning", code="unused_structure_rule", message="unused"
+        )
+        result = ScanResult(warnings=[warning])
+        assert result.is_success
+        assert result.warnings == [warning]
+
+    def test_default_lists_are_not_shared(self):
+        """Test that each instance gets its own list instances."""
+        first = ScanResult()
+        second = ScanResult()
+        first.errors.append(
+            ScanIssue(severity="error", code="unspecified_entry", message="nope")
+        )
+        assert not second.errors
 
 
 class TestMatchResult:


### PR DESCRIPTION
## Summary

Both processors now return a single `ScanResult(errors, warnings)` instead of three different shapes:

| API | before | after |
| --- | --- | --- |
| `FullScanProcessor.scan()` | `tuple[list[ScanIssue], list[ScanIssue]]` | `ScanResult` |
| `FullScanProcessor.scan_directory()` | `list[ScanIssue]` | `ScanResult` |
| `DiffScanProcessor.check_paths()` | `list[ScanIssue]` | `ScanResult` |

`ScanResult.is_success` encodes the "warnings do not fail a scan" rule in one place instead of at each call site, and `_perform_scan` no longer has to pad a directory scan with an empty warnings list to match `scan()`'s shape.

`check_path()` deliberately keeps returning `ScanIssue | None` — it answers a question about one path rather than producing a scan outcome, so wrapping it would add ceremony without removing a special case.

`ScanResult` is exported from the package root alongside `ScanIssue`. It is **not** added to the deprecated `repo_structure_lib` shim, which exists to keep pre-split imports working rather than to carry new API.

## Notes

`full_scan_test.py`'s local `_check_repo_directory_structure` helper still returns a `(errors, warnings)` tuple, now unpacked from the `ScanResult`. That keeps ~40 assertion sites untouched, so the diff shows the API change rather than mechanical churn. The new shape is covered directly by `TestScanResult` in `models_test.py` and by the updated `check_paths` assertions.

## Test plan

- [x] `uv run --extra dev pytest` — 245 passed (4 new)
- [x] `uv run repo_structure full-scan` — succeeds
- [x] `uv run prek run --all-files` — all hooks pass

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)