### PR TITLE
Phase 5.2: Build ScanIssue with final message at detection site

### DIFF
--- a/repo_structure/diff_scan.py
+++ b/repo_structure/diff_scan.py
@@ -1,6 +1,7 @@
 """Library functions for repo structure directory verification."""
 
 import logging
+from dataclasses import replace
 from pathlib import Path
 from typing import Iterator
 
@@ -12,6 +13,7 @@ from .models import (
     Entry,
     Flags,
     MatchFailure,
+    MatchFailureCode,
     ScanIssue,
     ScanResult,
     StructureRuleList,
@@ -32,6 +34,11 @@ from .scanning import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_MATCH_FAILURE_LABEL: dict[MatchFailureCode, str] = {
+    "forbidden_entry": "Forbidden",
+    "unspecified_entry": "Unspecified",
+}
 
 
 class DiffScanProcessor:
@@ -72,16 +79,22 @@ class DiffScanProcessor:
             yield rel_dir, part, is_directory
 
     def _check_path_in_backlog(
-        self, backlog: StructureRuleList, path: str, base_dir: str = ""
+        self,
+        backlog: StructureRuleList,
+        rel_path: str,
+        original_path: str,
+        map_dir: str,
     ) -> ScanIssue | None:
         """Check if path is valid in backlog and return ScanIssue if invalid.
 
         Args:
             backlog: List of structure rules to check against
-            path: Path to check (relative to base_dir)
-            base_dir: Base directory that path is relative to (relative to repo root)
+            rel_path: Path to check, relative to the map dir
+            original_path: Path as given to `check_path`, used for reporting
+            map_dir: Map dir `rel_path` is relative to, used for reporting
         """
-        for rel_dir, entry_name, is_dir in self._incremental_path_split(path):
+        base_dir = map_dir_to_rel_dir(map_dir)
+        for rel_dir, entry_name, is_dir in self._incremental_path_split(rel_path):
             if skip_entry(
                 Entry(
                     path=entry_name, rel_dir=rel_dir, is_dir=is_dir, is_symlink=False
@@ -100,7 +113,15 @@ class DiffScanProcessor:
             )
 
             if isinstance(match_result, MatchFailure):
-                return match_result.issue
+                return ScanIssue(
+                    severity="error",
+                    code=match_result.code,
+                    message=(
+                        f"{_MATCH_FAILURE_LABEL[match_result.code]} entry "
+                        f"'{original_path}' found. Map dir: '{map_dir}'"
+                    ),
+                    path=original_path,
+                )
 
             _LOGGER.debug("  Found match for path '%s'", entry_name)
 
@@ -115,7 +136,9 @@ class DiffScanProcessor:
                 entry_name, backlog_match, full_rel_dir, self.flags.verbose
             )
             if companion_issue:
-                return companion_issue
+                # The companion check only knows the entry name; report the
+                # path the caller asked about.
+                return replace(companion_issue, path=original_path)
 
             if is_dir:
                 backlog = expand_use_rule(
@@ -151,29 +174,18 @@ class DiffScanProcessor:
             entries are present.
         """
         map_dir = self._get_corresponding_map_dir(path)
+        base_dir = map_dir_to_rel_dir(map_dir)
         backlog = map_dir_to_entry_backlog(
             self.config.directory_map,
             self.config.structure_rules,
-            map_dir_to_rel_dir(map_dir),
+            base_dir,
         )
         if not backlog:
             _LOGGER.debug("backlog empty - returning success")
             return None
 
-        base_dir = map_dir_to_rel_dir(map_dir)
         rel_path = str(Path(path).relative_to(base_dir)) if base_dir else path
-        issue = self._check_path_in_backlog(backlog, rel_path, base_dir)
-        if issue:
-            # Update the message to include the original path and map_dir context
-            if issue.code == "unspecified_entry":
-                issue.message = (
-                    f"Unspecified entry '{path}' found. Map dir: '{map_dir}'"
-                )
-            elif issue.code == "forbidden_entry":
-                issue.message = f"Forbidden entry '{path}' found. Map dir: '{map_dir}'"
-            issue.path = path
-
-        return issue
+        return self._check_path_in_backlog(backlog, rel_path, path, map_dir)
 
     def check_paths(self, paths: list[str]) -> ScanResult:
         """Check multiple paths efficiently using the same configuration.

--- a/repo_structure/diff_scan_test.py
+++ b/repo_structure/diff_scan_test.py
@@ -35,6 +35,41 @@ directory_map:
     assert issue.code == "forbidden_entry"
 
 
+def test_issue_reports_original_path_and_map_dir():
+    """Test that issues name the path as given and its map dir, not the segment."""
+    config_yaml = r"""
+structure_rules:
+  base_structure:
+    - description: 'Base structure with README'
+    - require: 'README\.md'
+  python_package:
+    - description: 'Python package structure'
+    - require: '.*\.py'
+    - forbid: '.*\.pyc'
+directory_map:
+  /:
+    - description: 'Root directory'
+    - use_rule: base_structure
+  /app/:
+    - description: 'Application directory'
+    - use_rule: python_package
+    """
+    config = Configuration(config_yaml, True)
+    processor = DiffScanProcessor(config)
+
+    issue = processor.check_path("app/notes.txt")
+    assert issue is not None
+    assert issue.code == "unspecified_entry"
+    assert issue.path == "app/notes.txt"
+    assert issue.message == "Unspecified entry 'app/notes.txt' found. Map dir: '/app/'"
+
+    issue = processor.check_path("app/main.pyc")
+    assert issue is not None
+    assert issue.code == "forbidden_entry"
+    assert issue.path == "app/main.pyc"
+    assert issue.message == "Forbidden entry 'app/main.pyc' found. Map dir: '/app/'"
+
+
 def test_matching_regex_dir():
     """Test with required file."""
     config_yaml = r"""

--- a/repo_structure/full_scan.py
+++ b/repo_structure/full_scan.py
@@ -162,8 +162,21 @@ class FullScanProcessor:
         entry: Entry,
         errors: list[ScanIssue],
     ) -> None:
-        match_result.issue.path = join_path_normalized(entry.rel_dir, entry.path)
-        errors.append(match_result.issue)
+        if match_result.code == "forbidden_entry":
+            message = f"Found forbidden entry: {match_result.entry_path}"
+        else:
+            display_path = match_result.entry_path + (
+                "/" if match_result.is_dir else ""
+            )
+            message = f"Found unspecified entry: '{display_path}'"
+        errors.append(
+            ScanIssue(
+                severity="error",
+                code=match_result.code,
+                message=message,
+                path=join_path_normalized(entry.rel_dir, entry.path),
+            )
+        )
 
     def _process_subdirectory(
         self,

--- a/repo_structure/models.py
+++ b/repo_structure/models.py
@@ -87,11 +87,21 @@ class MatchSuccess:
     index: int
 
 
+MatchFailureCode = Literal["forbidden_entry", "unspecified_entry"]
+
+
 @dataclass(frozen=True)
 class MatchFailure:
-    """Failed match: holds the resulting ScanIssue."""
+    """Failed match: why it failed and which entry caused it.
 
-    issue: ScanIssue
+    Deliberately carries no message. Only the caller knows the path and
+    map-dir context a message should mention, so each processor builds the
+    final ScanIssue itself instead of patching one built here.
+    """
+
+    code: MatchFailureCode
+    entry_path: str
+    is_dir: bool
 
 
 MatchResult = MatchSuccess | MatchFailure

--- a/repo_structure/models_test.py
+++ b/repo_structure/models_test.py
@@ -128,15 +128,21 @@ class TestMatchResult:
         """Test that MatchSuccess exposes the matched index."""
         assert MatchSuccess(index=3).index == 3
 
-    def test_match_failure_holds_issue(self):
-        """Test that MatchFailure exposes the issue."""
-        issue = ScanIssue(severity="error", code="unspecified_entry", message="nope")
-        assert MatchFailure(issue=issue).issue is issue
+    def test_match_failure_holds_reason_and_entry(self):
+        """Test that MatchFailure exposes the failure reason and entry."""
+        failure = MatchFailure(
+            code="unspecified_entry", entry_path="widget.cpp", is_dir=False
+        )
+        assert failure.code == "unspecified_entry"
+        assert failure.entry_path == "widget.cpp"
+        assert not failure.is_dir
 
     def test_variants_are_distinguishable(self):
         """Test that the two variants never compare equal."""
-        issue = ScanIssue(severity="error", code="unspecified_entry", message="nope")
-        assert MatchSuccess(index=0) != MatchFailure(issue=issue)
+        failure = MatchFailure(
+            code="unspecified_entry", entry_path="widget.cpp", is_dir=False
+        )
+        assert MatchSuccess(index=0) != failure
 
 
 class TestBuiltinDirectoryRules:

--- a/repo_structure/scanning.py
+++ b/repo_structure/scanning.py
@@ -175,25 +175,12 @@ def get_matching_item_index(
         if v.path.fullmatch(entry_path) and v.is_dir == is_dir:
             if v.is_forbidden:
                 return MatchFailure(
-                    issue=ScanIssue(
-                        severity="error",
-                        code="forbidden_entry",
-                        message=f"Found forbidden entry: {entry_path}",
-                        path=entry_path,
-                    )
+                    code="forbidden_entry", entry_path=entry_path, is_dir=is_dir
                 )
             _LOGGER.debug("  Found match at index %d: '%s'", i, v.path.pattern)
             return MatchSuccess(index=i)
 
-    display_path = entry_path + "/" if is_dir else entry_path
-    return MatchFailure(
-        issue=ScanIssue(
-            severity="error",
-            code="unspecified_entry",
-            message=f"Found unspecified entry: '{display_path}'",
-            path=entry_path,
-        )
-    )
+    return MatchFailure(code="unspecified_entry", entry_path=entry_path, is_dir=is_dir)
 
 
 def _find_matching_file_in_directory(


### PR DESCRIPTION
## Problem

`DiffScanProcessor.check_path` constructed a `ScanIssue` deep inside the match helper, then patched its `message` and `path` afterwards by switching on the issue's `code` field. `FullScanProcessor` did the same for `path`.

## Fix

`MatchFailure` now carries only the failure reason and the entry that caused it (`code`, `entry_path`, `is_dir`) instead of a pre-built `ScanIssue`. Each processor builds the final `ScanIssue` itself, at the point where the full path and map-dir context are actually known:

- `DiffScanProcessor._check_path_in_backlog` takes `original_path` and `map_dir` and emits the finished issue directly. Companion issues pick up the caller's path via `dataclasses.replace` instead of mutation.
- `FullScanProcessor._handle_match_failure` builds its own issue with the repo-relative path.

Reported messages and paths are unchanged — added `test_issue_reports_original_path_and_map_dir` to pin the diff-scan wording, which nothing covered before.

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)