### PR TITLE
Phase 5.3: Replace format_report if/elif chain with a registry

### DIFF
--- a/repo_structure/__main__.py
+++ b/repo_structure/__main__.py
@@ -3,7 +3,6 @@
 import logging
 import sys
 from typing import cast
-from typing import Literal
 import time
 from pathlib import Path
 
@@ -16,7 +15,7 @@ from .full_scan import (
 )
 from .diff_scan import DiffScanProcessor
 from .config import Configuration
-from .report import generate_report, format_report
+from .report import FORMATTERS, ReportFormat, generate_report, format_report
 
 try:
     from ._version import version as VERSION
@@ -297,7 +296,7 @@ def diff_scan(ctx: click.Context, config_path: str, paths: list[str]) -> None:
     "--output_format",
     "-f",
     "output_format",
-    type=click.Choice(["text", "json", "markdown"]),
+    type=click.Choice(list(FORMATTERS)),
     help="Output format for the report.",
     default="text",
     show_default=True,
@@ -334,9 +333,7 @@ def report(
     config = _load_configuration(config_path, flags.verbose)
     report_data = generate_report(config, repo_root)
 
-    formatted_report = format_report(
-        report_data, cast(Literal["text", "json", "markdown"], output_format)
-    )
+    formatted_report = format_report(report_data, cast(ReportFormat, output_format))
 
     if output:
         try:

--- a/repo_structure/__main___test.py
+++ b/repo_structure/__main___test.py
@@ -1,7 +1,9 @@
 """Main tests module."""
 
+import click
 from click.testing import CliRunner
 from .__main__ import repo_structure
+from .report import FORMATTERS
 
 
 def test_main_full_scan_success():
@@ -345,3 +347,14 @@ def test_report_command_help():
 
     assert result.exit_code == 0
     assert "Generate a report of the configuration structure" in result.output
+
+
+def test_report_output_format_choices_match_registry():
+    """The CLI offers exactly the formats registered in FORMATTERS."""
+    report_command = repo_structure.commands["report"]
+    output_format = next(
+        param for param in report_command.params if param.name == "output_format"
+    )
+
+    assert isinstance(output_format.type, click.Choice)
+    assert list(output_format.type.choices) == list(FORMATTERS)

--- a/repo_structure/report.py
+++ b/repo_structure/report.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Callable, Literal
 from .config import Configuration
 from .models import (
     BUILTIN_DIRECTORY_RULES,
@@ -12,6 +12,9 @@ from .models import (
     IGNORE_RULE,
     StructureRuleMap,
 )
+
+ReportFormat = Literal["text", "json", "markdown"]
+"""Output formats supported by :data:`FORMATTERS`."""
 
 
 @dataclass
@@ -533,9 +536,21 @@ def format_report_markdown(report: ConfigurationReport) -> str:
     return "\n".join(lines)
 
 
+FORMATTERS: dict[ReportFormat, Callable[[ConfigurationReport], str]] = {
+    "text": format_report_text,
+    "json": format_report_json,
+    "markdown": format_report_markdown,
+}
+"""Registry of report formatters, keyed by output format.
+
+Add a new format by registering its formatter here; the CLI derives its
+``--output-format`` choices from these keys.
+"""
+
+
 def format_report(
     report: ConfigurationReport,
-    format_type: Literal["text", "json", "markdown"] = "text",
+    format_type: ReportFormat = "text",
 ) -> str:
     """Format the report in the specified format.
 
@@ -545,9 +560,8 @@ def format_report(
 
     Returns:
         A formatted representation of the report.
+
+    Raises:
+        KeyError: If ``format_type`` is not a registered format.
     """
-    if format_type == "json":
-        return format_report_json(report)
-    if format_type == "markdown":
-        return format_report_markdown(report)
-    return format_report_text(report)
+    return FORMATTERS[format_type](report)

--- a/repo_structure/report_test.py
+++ b/repo_structure/report_test.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .config import Configuration
 from .report import (
+    FORMATTERS,
     generate_report,
     format_report_text,
     format_report_json,
@@ -215,6 +216,26 @@ directory_map:
     # Test Markdown format
     markdown_output = format_report(report, "markdown")
     assert "# Repository Structure Configuration Report" in markdown_output
+
+
+def test_format_report_dispatches_to_every_registered_formatter():
+    """Every registry entry is reachable through format_report."""
+    test_yaml = """
+structure_rules:
+  basic_rule:
+    - description: 'Basic rule for documentation'
+    - require: 'README\\.md'
+
+directory_map:
+  /:
+    - description: 'Root directory'
+    - use_rule: basic_rule
+"""
+    config = Configuration.from_yaml_string(test_yaml)
+    report = generate_report(config)
+
+    for format_type, formatter in FORMATTERS.items():
+        assert format_report(report, format_type) == formatter(report)
 
 
 def test_multiple_rules_per_directory():


### PR DESCRIPTION
Closes #185.

## Problem

`format_report` dispatched between text / json / markdown via an if/elif chain, so adding a format required editing the dispatch.

## Change

- `FORMATTERS: dict[ReportFormat, Callable[[ConfigurationReport], str]]` registry; `format_report` is now a single lookup.
- The three formats were spelled out in three places — the dispatch's `Literal`, the CLI's `click.Choice`, and the `cast` in the `report` command. Extracted a `ReportFormat` alias and the CLI now derives its choices from `FORMATTERS.keys()`, so registering a formatter is the only edit a new format needs.
- Tests: every registry entry is reachable through `format_report`, and the CLI's `--output-format` choices match the registry.

## Notes

- The issue's optional suggestion of a `formatters/` subpackage is not done here. The three formatters share private helpers (`_normalize_directory_display`, `_format_repository_info_*`) that would have to move or be duplicated, and each new module would need a companion `_test.py` under `repo_structure.yaml`'s companion rule. That is a separate refactor from the OCP fix this issue asks for.
- One behavior change: an unregistered format now raises `KeyError` instead of silently falling back to text. `click.Choice` and the `ReportFormat` annotation both prevent that from being reachable via the CLI; documented in the docstring.

Full suite (248 tests) and `prek run --all-files` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)