### PR TITLE
Phase 6.1: Drop os.chdir from test fixtures

### DIFF
--- a/repo_structure/benchmark_test.py
+++ b/repo_structure/benchmark_test.py
@@ -4,7 +4,7 @@ import os
 from typing import Final
 import pytest
 
-from .test_lib import with_random_repo_structure_in_tmpdir
+from .test_lib import create_random_repo_structure
 from .full_scan import FullScanProcessor
 from .config import Configuration
 
@@ -26,9 +26,9 @@ directory_map:
 @pytest.mark.skipif(
     os.environ.get("GITHUB_RUN_ID", "") != "", reason="Only run on local machine."
 )
-@with_random_repo_structure_in_tmpdir()
-def test_benchmark_repo_structure_default(benchmark):
+def test_benchmark_repo_structure_default(benchmark, tmp_path):
     """Test repo_structure benchmark."""
+    repo = create_random_repo_structure(tmp_path)
     config = Configuration(ALLOW_ALL_CONFIG, True)
-    processor = FullScanProcessor(".", config)
+    processor = FullScanProcessor(repo, config)
     benchmark(processor.scan)

--- a/repo_structure/diff_scan.py
+++ b/repo_structure/diff_scan.py
@@ -44,15 +44,24 @@ _MATCH_FAILURE_LABEL: dict[MatchFailureCode, str] = {
 class DiffScanProcessor:
     """Handles differential scanning of specific paths with stateful configuration."""
 
-    def __init__(self, config: Configuration, flags: Flags | None = None):
+    def __init__(
+        self,
+        config: Configuration,
+        flags: Flags | None = None,
+        repo_root: str = ".",
+    ):
         """Initialize the diff scanner with static configuration.
 
         Args:
             config: Repository structure configuration
             flags: Scanning flags (verbose, follow_symlinks, include_hidden)
+            repo_root: Root directory the checked paths are relative to.
+                Defaults to the process CWD, which is what the pre-commit hook
+                and the CLI pass paths relative to.
         """
         self.config = config
         self.flags = flags if flags is not None else Flags()
+        self.repo_root = repo_root
 
     def _incremental_path_split(
         self, path_to_split: str
@@ -133,7 +142,10 @@ class DiffScanProcessor:
                 join_path_normalized(base_dir, rel_dir) if base_dir else rel_dir
             )
             companion_issue = check_companion_files(
-                entry_name, backlog_match, full_rel_dir, self.flags.verbose
+                entry_name,
+                backlog_match,
+                str(Path(self.repo_root) / full_rel_dir),
+                self.flags.verbose,
             )
             if companion_issue:
                 # The companion check only knows the entry name; report the

--- a/repo_structure/diff_scan_test.py
+++ b/repo_structure/diff_scan_test.py
@@ -4,7 +4,7 @@
 from .models import Flags
 from .config import Configuration
 from .diff_scan import DiffScanProcessor
-from .test_lib import with_repo_structure_in_tmpdir
+from .test_lib import create_repo_structure
 
 
 def test_matching_regex():
@@ -303,15 +303,16 @@ directory_map:
     assert "another_invalid.txt" in issue_paths
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_companion_check(tmp_path):
+    """Test that companion validates companion files exist."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 widget.cpp
 widget.h
 engine.cpp
-"""
-)
-def test_companion_check():
-    """Test that companion validates companion files exist."""
+""",
+    )
     test_yaml = r"""
 structure_rules:
   cpp_with_headers:
@@ -325,7 +326,7 @@ directory_map:
     - use_rule: cpp_with_headers
 """
     config = Configuration(test_yaml, param1_is_yaml_string=True)
-    scanner = DiffScanProcessor(config)
+    scanner = DiffScanProcessor(config, repo_root=repo)
 
     # widget.cpp should pass (has widget.h)
     issue = scanner.check_path("widget.cpp")
@@ -338,17 +339,18 @@ directory_map:
     assert "Missing required companion" in issue.message
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_companion_multiple(tmp_path):
+    """Test multiple companion requirements."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 lib.cpp
 lib.h
 lib_test.cpp
 util.cpp
 util.h
-"""
-)
-def test_companion_multiple():
-    """Test multiple companion requirements."""
+""",
+    )
     test_yaml = r"""
 structure_rules:
   cpp_with_test:
@@ -363,7 +365,7 @@ directory_map:
     - use_rule: cpp_with_test
 """
     config = Configuration(test_yaml, param1_is_yaml_string=True)
-    scanner = DiffScanProcessor(config)
+    scanner = DiffScanProcessor(config, repo_root=repo)
 
     # lib.cpp should pass (has both companions)
     issue = scanner.check_path("lib.cpp")
@@ -375,16 +377,17 @@ directory_map:
     assert "util_test.cpp" in issue.message
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_companion_subdirectory(tmp_path):
+    """Test that companions can be in subdirectories."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 widget.cpp
 include/
 include/widget.h
 engine.cpp
-"""
-)
-def test_companion_subdirectory():
-    """Test that companions can be in subdirectories."""
+""",
+    )
     test_yaml = r"""
 structure_rules:
   cpp_with_header_in_include:
@@ -401,7 +404,7 @@ directory_map:
     - use_rule: cpp_with_header_in_include
 """
     config = Configuration(test_yaml, param1_is_yaml_string=True)
-    scanner = DiffScanProcessor(config)
+    scanner = DiffScanProcessor(config, repo_root=repo)
 
     # widget.cpp should pass (has include/widget.h)
     issue = scanner.check_path("widget.cpp")
@@ -413,15 +416,16 @@ directory_map:
     assert "include/engine.h" in issue.message
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_companion_no_expansion(tmp_path):
+    """Test that companion works without named groups in diff-scan."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 widget.cpp
 include/
 include/gadget.h
-"""
-)
-def test_companion_no_expansion():
-    """Test that companion works without named groups in diff-scan."""
+""",
+    )
     test_yaml = r"""
 structure_rules:
     cpp_with_header_in_include:
@@ -439,7 +443,7 @@ directory_map:
     - use_rule: cpp_with_header_in_include
 """
     config = Configuration(test_yaml, param1_is_yaml_string=True)
-    scanner = DiffScanProcessor(config)
+    scanner = DiffScanProcessor(config, repo_root=repo)
 
     # widget.cpp should pass (has both companions)
     issue = scanner.check_path("widget.cpp")

--- a/repo_structure/full_scan.py
+++ b/repo_structure/full_scan.py
@@ -56,11 +56,17 @@ class FullScanProcessor:
         self.git_ignore = self._get_git_ignore()
 
     def _get_git_ignore(self) -> Callable[[str], bool] | None:
-        """Get gitignore parser, cached for the lifetime of the scan."""
+        """Get gitignore parser, cached for the lifetime of the scan.
+
+        The returned matcher takes a path relative to the repository root and
+        resolves it against that root, not against the process CWD.
+        """
         git_ignore_path = Path(self.repo_root) / ".gitignore"
-        if git_ignore_path.is_file():
-            return parse_gitignore(str(git_ignore_path))
-        return None
+        if not git_ignore_path.is_file():
+            return None
+
+        matches = parse_gitignore(str(git_ignore_path))
+        return lambda rel_path: matches(str(Path(self.repo_root) / rel_path))
 
     def _check_required_entries_missing(
         self,
@@ -133,7 +139,10 @@ class FullScanProcessor:
 
             # Check for required companion files
             companion_issue = check_companion_files(
-                entry.path, backlog[idx], rel_dir, self.flags.verbose
+                entry.path,
+                backlog[idx],
+                str(Path(self.repo_root) / rel_dir),
+                self.flags.verbose,
             )
             if companion_issue:
                 errors.append(companion_issue)

--- a/repo_structure/full_scan_test.py
+++ b/repo_structure/full_scan_test.py
@@ -12,35 +12,36 @@ from .full_scan import (
 from .errors import ConfigurationParseError
 from .models import Flags
 
-from .test_lib import with_repo_structure_in_tmpdir
+from .test_lib import create_repo_structure
 
 
 def _check_repo_directory_structure(
+    repo_root: str,
     config: Configuration,
     flags: Flags = Flags(),
 ) -> tuple[list[ScanIssue], list[ScanIssue]]:
     """Check repository structure and return errors and warnings instead of asserting."""
-    processor = FullScanProcessor(".", config, flags)
+    processor = FullScanProcessor(repo_root, config, flags)
     result = processor.scan()
     return result.errors, result.warnings
 
 
-@with_repo_structure_in_tmpdir("")
 def test_all_empty():
-    """Test empty directory structure and spec."""
+    """Test empty spec."""
     config_yaml = r"""
 """
     with pytest.raises(ConfigurationParseError):
         Configuration(config_yaml, True)
 
 
-@with_repo_structure_in_tmpdir(
-    """
-README.md
-"""
-)
-def test_matching_regex():
+def test_matching_regex(tmp_path):
     """Test with required file."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+README.md
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -52,19 +53,20 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_required_dir(tmp_path):
+    """Test with required directory."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 python/
 python/main.py
-"""
-)
-def test_required_dir():
-    """Test with required directory."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -78,21 +80,22 @@ directory_map:
     - use_rule: base_structure
         """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_unspecified_dir(tmp_path):
+    """Test with unspecified directory in directory, where only files are allowed."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 README.md
 python/
 python/main.py
 unspecified/
-"""
-)
-def test_unspecified_dir():
-    """Test with unspecified directory in directory, where only files are allowed."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -107,19 +110,20 @@ directory_map:
     - use_rule: base_structure
         """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "unspecified_entry"
     assert "unspecified" in errors[0].path
 
 
-@with_repo_structure_in_tmpdir(
-    """
-README.md
-"""
-)
-def test_missing_root_mapping():
+def test_missing_root_mapping(tmp_path):
     """Test missing root mapping."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+README.md
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -131,18 +135,19 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "missing_root_mapping"
 
 
-@with_repo_structure_in_tmpdir(
-    """
-README.md
-"""
-)
-def test_missing_required_file():
+def test_missing_required_file(tmp_path):
     """Test missing required file."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+README.md
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -155,18 +160,19 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "missing_required_entries"
 
 
-@with_repo_structure_in_tmpdir(
-    """
-README.md
-"""
-)
-def test_missing_required_dir():
+def test_missing_required_dir(tmp_path):
     """Test missing required directory."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+README.md
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -181,20 +187,21 @@ directory_map:
     - use_rule: base_structure
         """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "missing_required_entries"
 
 
-@with_repo_structure_in_tmpdir(
-    """
-README.md
-"""
-)
-def test_fail_rule_precedence():
+def test_fail_rule_precedence(tmp_path):
     """Test rule precedence. This needs to fail because the wildcard consumes all matches.
 
     The first match wins and thus the README.md will never be reached."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+README.md
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -207,19 +214,20 @@ directory_map:
     - use_rule: base_structure
 """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "missing_required_entries"
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_multi_use_rule(tmp_path):
+    """Test using multiple rules."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 README.md
 main.py
-"""
-)
-def test_multi_use_rule():
-    """Test using multiple rules."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -235,18 +243,19 @@ directory_map:
     - use_rule: python_package
     """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
-README.md
-"""
-)
-def test_multi_use_rule_missing_py_file():
+def test_multi_use_rule_missing_py_file(tmp_path):
     """Test missing required pattern file while using multi rules."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+README.md
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -262,19 +271,20 @@ directory_map:
     - use_rule: python_package
     """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "missing_required_entries"
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_conflicting_file_and_dir_names(tmp_path):
+    """Test two required entries, one file, one dir. Need to pass ensuring distinct detection."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 filename.txt
 dirname/
-"""
-)
-def test_conflicting_file_and_dir_names():
-    """Test two required entries, one file, one dir. Need to pass ensuring distinct detection."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -289,18 +299,19 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
-dirname/
-"""
-)
-def test_conflicting_dir_name():
+def test_conflicting_dir_name(tmp_path):
     """Ensure that a matching directory does not suffice a required file."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+dirname/
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -312,19 +323,20 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 2
     assert errors[0].code == "missing_required_entries"
     assert errors[1].code == "unspecified_entry"
 
 
-@with_repo_structure_in_tmpdir(
-    """
-filename.txt
-"""
-)
-def test_conflicting_file_name():
+def test_conflicting_file_name(tmp_path):
     """Ensure that a matching file does not suffice a required directory."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+filename.txt
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -338,19 +350,20 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 2
     assert errors[0].code == "missing_required_entries"
     assert errors[1].code == "unspecified_entry"
 
 
-@with_repo_structure_in_tmpdir(
-    """
-filename.txt
-"""
-)
-def test_filename_with_bad_substring_match():
+def test_filename_with_bad_substring_match(tmp_path):
     """Ensure substring match is not enough to match."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+filename.txt
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -362,19 +375,20 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 2
     assert errors[0].code == "missing_required_entries"
     assert errors[1].code == "unspecified_entry"
 
 
-@with_repo_structure_in_tmpdir(
-    """
-LICENSE
-"""
-)
-def test_required_file_in_optional_directory_no_entry():
+def test_required_file_in_optional_directory_no_entry(tmp_path):
     """Test required file under optional directory - no entry."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+LICENSE
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -389,19 +403,20 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_required_file_in_optional_directory_with_entry(tmp_path):
+    """Test required file under optional directory - with directory entry."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 LICENSE
 doc/
-"""
-)
-def test_required_file_in_optional_directory_with_entry():
-    """Test required file under optional directory - with directory entry."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -416,20 +431,21 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "missing_required_entries"
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_required_file_in_optional_directory_with_entry_and_exists(tmp_path):
+    """Test required file under optional directory - with directory entry and file."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 LICENSE
 doc/
 doc/README.md
-"""
-)
-def test_required_file_in_optional_directory_with_entry_and_exists():
-    """Test required file under optional directory - with directory entry and file."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -444,21 +460,22 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_use_rule_recursive(tmp_path):
+    """Test self-recursion from a use rule."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 main.cpp
 README.md
 lib/
 lib/lib.cpp
-"""
-)
-def test_use_rule_recursive():
-    """Test self-recursion from a use rule."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -476,21 +493,22 @@ directory_map:
     - use_rule: cpp_source
     """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_fail_use_rule_recursive(tmp_path):
+    """Ensure use_rules are not mixed up in recursion."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 main.py
 README.md
 lib/
 lib/README.md
-"""
-)
-def test_fail_use_rule_recursive():
-    """Ensure use_rules are not mixed up in recursion."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -508,7 +526,7 @@ directory_map:
     - use_rule: python_package
     """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 2
     assert errors[0].code == "missing_required_entries"
     assert errors[0].path == "lib"
@@ -516,16 +534,17 @@ directory_map:
     assert errors[1].path == "lib/README.md"
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_fail_directory_mapping_precedence(tmp_path):
+    """Test that directories from directory_mapping take precedence."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 main.py
 README.md
 lib/
 lib/README.md
-"""
-)
-def test_fail_directory_mapping_precedence():
-    """Test that directories from directory_mapping take precedence."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -546,13 +565,16 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_succeed_elaborate_use_rule_recursive(tmp_path):
+    """Test deeper nested use rule setup with existing entries."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 README.md
 app/
 app/main.py
@@ -563,10 +585,8 @@ app/lib/sub_lib/lib.py
 app/lib/sub_lib/tool/
 app/lib/sub_lib/tool/README.md
 app/lib/sub_lib/tool/main.py
-"""
-)
-def test_succeed_elaborate_use_rule_recursive():
-    """Test deeper nested use rule setup with existing entries."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -590,19 +610,20 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_succeed_ignored_hidden_file(tmp_path):
+    """Test existing ignored hidden file - hidden files not tracked."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 .hidden.md
 README.md
-"""
-)
-def test_succeed_ignored_hidden_file():
-    """Test existing ignored hidden file - hidden files not tracked."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -616,18 +637,19 @@ directory_map:
     config = Configuration(config_yaml, True)
     flags = Flags()
     flags.include_hidden = False
-    errors, warnings = _check_repo_directory_structure(config, flags)
+    errors, warnings = _check_repo_directory_structure(repo, config, flags)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
-README.md
-"""
-)
-def test_fail_hidden_file_required_despite_hidden_disabled():
+def test_fail_hidden_file_required_despite_hidden_disabled(tmp_path):
     """Test with a missing, required, hidden file - hidden files not tracked."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+README.md
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -642,20 +664,21 @@ directory_map:
     config = Configuration(config_yaml, True)
     flags = Flags()
     flags.include_hidden = True
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "missing_required_entries"
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_fail_unspecified_hidden_files_when_hidden_enabled(tmp_path):
+    """Test for unspecified hidden file - hidden files tracked."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 README.md
 .hidden.md
 .unspecified.md
-"""
-)
-def test_fail_unspecified_hidden_files_when_hidden_enabled():
-    """Test for unspecified hidden file - hidden files tracked."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -670,20 +693,21 @@ directory_map:
     config = Configuration(config_yaml, True)
     flags = Flags()
     flags.include_hidden = True
-    errors, _ = _check_repo_directory_structure(config, flags)
+    errors, _ = _check_repo_directory_structure(repo, config, flags)
     assert len(errors) == 1
     assert errors[0].code == "unspecified_entry"
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_succeed_gitignored_file(tmp_path):
+    """Test for ignored file from gitignore."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 README.md
 ignored.md
 .gitignore:ignored.md
-"""
-)
-def test_succeed_gitignored_file():
-    """Test for ignored file from gitignore."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -695,19 +719,51 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
+def test_succeed_gitignored_file_in_subdirectory(tmp_path):
+    """Test that gitignore patterns are matched against the full relative path."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
+README.md
+python/
+python/main.py
+python/ignored.md
+.gitignore:python/ignored.md
+""",
+    )
+    config_yaml = r"""
+structure_rules:
+  base_structure:
+    - description: 'Base structure with README'
+    - require: 'README\.md'
+    - require: 'python/'
+      if_exists:
+      - require: 'main\.py'
+directory_map:
+  /:
+    - description: 'Root directory'
+    - use_rule: base_structure
     """
+    config = Configuration(config_yaml, True)
+    errors, warnings = _check_repo_directory_structure(repo, config)
+    assert len(errors) == 0
+    assert len(warnings) == 0
+
+
+def test_fail_unspecified_link(tmp_path):
+    """Test for unspecified symlink."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 README.md
 link -> README.md
-"""
-)
-def test_fail_unspecified_link():
-    """Test for unspecified symlink."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -721,20 +777,21 @@ directory_map:
     config = Configuration(config_yaml, True)
     flags = Flags()
     flags.follow_symlinks = True
-    errors, warnings = _check_repo_directory_structure(config, flags)
+    errors, warnings = _check_repo_directory_structure(repo, config, flags)
     assert len(errors) == 1
     assert errors[0].code == "unspecified_entry"
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_succeed_specified_link(tmp_path):
+    """Test for specified symlink."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 README.md
 link -> README.md
-"""
-)
-def test_succeed_specified_link():
-    """Test for specified symlink."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -749,13 +806,16 @@ directory_map:
     config = Configuration(config_yaml, True)
     flags = Flags()
     flags.follow_symlinks = True
-    errors, warnings = _check_repo_directory_structure(config, flags)
+    errors, warnings = _check_repo_directory_structure(repo, config, flags)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_succeed_template_rule(tmp_path):
+    """Test template with single parameter."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 lidar/
 lidar/lidar_component.py
 lidar/doc/
@@ -764,10 +824,8 @@ driver/
 driver/driver_component.py
 driver/doc/
 driver/doc/driver.techspec.md
-"""
-)
-def test_succeed_template_rule():
-    """Test template with single parameter."""
+""",
+    )
     config_yaml = r"""
 templates:
   component:
@@ -786,13 +844,16 @@ directory_map:
         component: ['lidar', 'driver']
 """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_fail_template_rule_missing_file(tmp_path):
+    """Test template with single parameter missing file."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 lidar/
 lidar/lidar_component.py
 lidar/doc/
@@ -800,10 +861,8 @@ lidar/doc/lidar.techspec.md
 driver/
 driver/driver_component.py
 driver/doc/
-"""
-)
-def test_fail_template_rule_missing_file():
-    """Test template with single parameter missing file."""
+""",
+    )
     config_yaml = r"""
 templates:
   component:
@@ -822,13 +881,16 @@ directory_map:
         component: ['lidar', 'driver']
 """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "missing_required_entries"
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_succeed_template_rule_if_exists(tmp_path):
+    """Test template with if_exists clause and optional dir missing."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 lidar/
 lidar/lidar_component.py
 lidar/doc/
@@ -836,10 +898,8 @@ lidar/doc/lidar.techspec.md
 driver/
 driver/driver_component.py
 driver/
-"""
-)
-def test_succeed_template_rule_if_exists():
-    """Test template with if_exists clause and optional dir missing."""
+""",
+    )
     config_yaml = r"""
 templates:
   component:
@@ -858,13 +918,16 @@ directory_map:
         component: ['lidar', 'driver']
 """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_succeed_template_rule_subdirectory_map(tmp_path):
+    """Test template with single parameter and subdirectory map."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 lidar/
 lidar/lidar_component.py
 lidar/doc/
@@ -881,10 +944,8 @@ subdir/camera/
 subdir/camera/camera_component.py
 subdir/camera/doc/
 subdir/camera/doc/camera.techspec.md
-"""
-)
-def test_succeed_template_rule_subdirectory_map():
-    """Test template with single parameter and subdirectory map."""
+""",
+    )
     config_yaml = r"""
 templates:
   component:
@@ -908,13 +969,16 @@ directory_map:
         component: ['control', 'camera']
 """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_fail_template_rule_subdirectory_map_missing_file(tmp_path):
+    """Test template with single parameter and subdirectory map missing file."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 lidar/
 lidar/lidar_component.py
 lidar/doc/
@@ -930,10 +994,8 @@ subdir/camera/
 subdir/camera/camera_component.py
 subdir/camera/doc/
 subdir/camera/doc/camera.techspec.md
-"""
-)
-def test_fail_template_rule_subdirectory_map_missing_file():
-    """Test template with single parameter and subdirectory map missing file."""
+""",
+    )
     config_yaml = r"""
 templates:
   component:
@@ -957,13 +1019,16 @@ directory_map:
         component: ['control', 'camera']
 """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "missing_required_entries"
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_succeed_template_rule_multiple_expansions(tmp_path):
+    """Test template with single parameter and subdirectory map."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 lidar/
 lidar/lidar_component.rs
 lidar/doc/
@@ -980,10 +1045,8 @@ subdir/camera/
 subdir/camera/camera_component.py
 subdir/camera/doc/
 subdir/camera/doc/camera.techspec.md
-"""
-)
-def test_succeed_template_rule_multiple_expansions():
-    """Test template with single parameter and subdirectory map."""
+""",
+    )
     config_yaml = r"""
 templates:
   example_template:
@@ -1009,13 +1072,16 @@ directory_map:
         extension: ['py']
 """
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config)
+    errors, warnings = _check_repo_directory_structure(repo, config)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_succeed_with_verbose(tmp_path):
+    """Test enforcement with verbose flag enabled."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 README.md
 link_to_skip -> README.md
 doc/
@@ -1024,10 +1090,8 @@ lidar/
 lidar/lidar_component.py
 lidar/doc/
 lidar/doc/lidar.techspec.md
-"""
-)
-def test_succeed_with_verbose():
-    """Test enforcement with verbose flag enabled."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -1056,21 +1120,22 @@ directory_map:
     flags = Flags()
     flags.verbose = True
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config, flags)
+    errors, warnings = _check_repo_directory_structure(repo, config, flags)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_forbid_file(tmp_path):
+    """Test with required directory."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 README.md
 CMakeLists.txt
 python/
 python/main.py
-"""
-)
-def test_forbid_file():
-    """Test with required directory."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -1086,21 +1151,22 @@ directory_map:
     - use_rule: base_structure
         """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
     assert len(errors) == 1
     assert errors[0].code == "forbidden_entry"
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_ignore_rule(tmp_path):
+    """Test with ignored directory."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 README.md
 python/
 python/whatever.py
 python/this_is_ignored.py
-"""
-)
-def test_ignore_rule():
-    """Test with ignored directory."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -1117,21 +1183,24 @@ directory_map:
     flags = Flags()
     flags.verbose = True
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config, flags)
+    errors, warnings = _check_repo_directory_structure(repo, config, flags)
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
-README.md
-"""
-)
-def test_warn_on_unused_structure_rule():  # pylint: disable=import-outside-toplevel
+def test_warn_on_unused_structure_rule(
+    tmp_path,
+):  # pylint: disable=import-outside-toplevel
     """Warn if a structure rule exists in the configuration but is never used in the scan.
 
     Using the non-throwing API, warnings are returned as ScanIssue entries.
     """
+    repo = create_repo_structure(
+        tmp_path,
+        """
+README.md
+""",
+    )
     config_yaml = r"""
 structure_rules:
   base_structure:
@@ -1146,22 +1215,23 @@ directory_map:
     - use_rule: base_structure
     """
     config = Configuration(config_yaml, True)
-    processor = FullScanProcessor(".", config, Flags())
+    processor = FullScanProcessor(repo, config, Flags())
     warnings = processor.scan().warnings
     assert any(
         "unused_rule" in i.message for i in warnings
     ), f"Expected unused rule warning, got: {warnings}"
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_companion_full_scan(tmp_path):
+    """Test that full scan detects missing companion files."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 widget.cpp
 widget.h
 engine.cpp
-"""
-)
-def test_companion_full_scan():
-    """Test that full scan detects missing companion files."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   cpp_with_headers:
@@ -1175,7 +1245,7 @@ directory_map:
     - use_rule: cpp_with_headers
 """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
 
     # Should have error for engine.cpp missing engine.h
     # Note: We get 2 errors - one from companion check, one from missing required pattern
@@ -1186,17 +1256,18 @@ directory_map:
     assert "engine.h" in companion_errors[0].message
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_companion_subdirectory_full_scan(tmp_path):
+    """Test that full scan detects missing companions in subdirectories."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 widget.cpp
 widget.h
 include/
 include/engine.h
 engine.cpp
-"""
-)
-def test_companion_subdirectory_full_scan():
-    """Test that full scan detects missing companions in subdirectories."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
   cpp_with_header_in_include:
@@ -1210,7 +1281,7 @@ directory_map:
     - use_rule: cpp_with_header_in_include
 """
     config = Configuration(config_yaml, True)
-    errors, _ = _check_repo_directory_structure(config)
+    errors, _ = _check_repo_directory_structure(repo, config)
 
     # Should have errors:
     # 1. widget.cpp missing include/widget.h companion
@@ -1222,15 +1293,16 @@ directory_map:
     assert "include/widget.h" in companion_errors[0].message
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_companion_no_expansion(tmp_path):
+    """Test that companion works without named groups."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 widget.cpp
 include/
 include/gadget.h
-"""
-)
-def test_companion_no_expansion():
-    """Test that companion works without named groups."""
+""",
+    )
     config_yaml = r"""
 structure_rules:
     cpp_with_header_in_include:
@@ -1247,24 +1319,25 @@ directory_map:
     flags = Flags()
     flags.verbose = True
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config, flags)
+    errors, warnings = _check_repo_directory_structure(repo, config, flags)
 
     assert len(errors) == 0
     assert len(warnings) == 0
 
 
-@with_repo_structure_in_tmpdir(
-    """
+def test_companion_with_template_parameters(tmp_path):
+    """Test that companions can use both template parameters and capture groups."""
+    repo = create_repo_structure(
+        tmp_path,
+        """
 controller.py
 controller_test.py
 service.rs
 service_test.rs
 utils.cpp
 utils_test.cpp
-"""
-)
-def test_companion_with_template_parameters():
-    """Test that companions can use both template parameters and capture groups."""
+""",
+    )
     config_yaml = r"""
 templates:
     module_with_test:
@@ -1283,7 +1356,7 @@ directory_map:
     flags = Flags()
     flags.verbose = True
     config = Configuration(config_yaml, True)
-    errors, warnings = _check_repo_directory_structure(config, flags)
+    errors, warnings = _check_repo_directory_structure(repo, config, flags)
 
     assert len(errors) == 0
     assert len(warnings) == 0

--- a/repo_structure/scanning.py
+++ b/repo_structure/scanning.py
@@ -41,7 +41,11 @@ def skip_entry(
     git_ignore: Callable[[str], bool] | None = None,
     flags: Flags | None = None,
 ) -> bool:
-    """Return True if the entry should be skipped/ignored."""
+    """Return True if the entry should be skipped/ignored.
+
+    `git_ignore` is called with the entry's path relative to the repository
+    root, so it must resolve that against the root rather than the process CWD.
+    """
     if flags is None:
         flags = Flags()
     skip_conditions = [
@@ -49,7 +53,7 @@ def skip_entry(
         (not flags.include_hidden and entry.path.startswith(".")),
         (entry.path == ".gitignore" and not entry.is_dir),
         (entry.path == ".git" and entry.is_dir),
-        (git_ignore and git_ignore(entry.path)),
+        (git_ignore and git_ignore(join_path_normalized(entry.rel_dir, entry.path))),
         (
             entry.is_dir
             and rel_dir_to_map_dir(join_path_normalized(entry.rel_dir, entry.path))
@@ -218,7 +222,7 @@ def _find_matching_file_in_directory(
 def check_companion_files(
     entry_name: str,
     matched_entry: RepoEntry,
-    rel_dir: str,
+    search_dir: str,
     verbose: bool = False,
 ) -> ScanIssue | None:
     """Check if required companion files exist for a matched entry.
@@ -226,7 +230,8 @@ def check_companion_files(
     Args:
         entry_name: Name of the file that was matched
         matched_entry: The RepoEntry that was matched
-        rel_dir: Relative directory where the file exists
+        search_dir: Directory to search companions in, resolved by the caller
+            against the repository root (not the process CWD)
         verbose: Enable verbose output
 
     Returns:
@@ -247,7 +252,7 @@ def check_companion_files(
     )
 
     # Check if required companions exist
-    base_dir = rel_dir if rel_dir else "."
+    base_dir = search_dir if search_dir else "."
     for companion in expanded_companions:
         if not companion.is_required:
             continue

--- a/repo_structure/test_lib.py
+++ b/repo_structure/test_lib.py
@@ -1,26 +1,19 @@
-"""Library functions for repo structure testing."""
+"""Library functions for repo structure testing.
+
+The helpers here build repository trees below a caller-supplied directory —
+typically pytest's ``tmp_path`` fixture — and return that directory. Nothing
+changes the process CWD, so tests must pass the returned path into the API
+under test.
+"""
 
 import os
-import shutil
-import tempfile
-from typing import Callable, TypeVar
 from pathlib import Path
 import random
 import string
-import functools
 
 
-def _get_tmp_dir() -> str:
-    return tempfile.mkdtemp()
-
-
-def _remove_tmp_dir(tmpdir: str) -> None:
-    shutil.rmtree(tmpdir)
-
-
-def _create_repo_directory_structure(specification: str) -> None:
-    """Creates a directory structure based on a specification file.
-    Must be run in the target directory.
+def create_repo_structure(base_path: Path, specification: str) -> str:
+    """Create a directory structure below base_path based on a specification.
 
     A specification file can contain the following entries:
     | Entry                      | Meaning                                                         |
@@ -28,67 +21,41 @@ def _create_repo_directory_structure(specification: str) -> None:
     | <filename>:<content>       | File with content <content> (single line only)                  |
     | <dirname>/                 | Directory                                                       |
     | <linkname> -> <targetfile> | Symbolic link with the name <linkname> pointing to <targetfile> |
+
+    Returns the repo root as a string, ready to hand to a scan processor.
     """
+    base_path.mkdir(parents=True, exist_ok=True)
     for item in specification.splitlines():
         if item.startswith("#") or item.strip() == "":
             continue
         if item.strip().endswith("/"):
-            os.makedirs(item.strip(), exist_ok=True)
+            (base_path / item.strip()).mkdir(parents=True, exist_ok=True)
         elif "->" in item:
             link_name, target_file = item.strip().split("->")
-            os.symlink(target_file.strip(), link_name.strip())
+            os.symlink(target_file.strip(), base_path / link_name.strip())
         else:
             file_content = "Created for testing only"
             if ":" in item:
                 file_name, file_content = item.strip().split(":")
             else:
                 file_name = item.strip()
-            with open(file_name.strip(), "w", encoding="utf-8") as f:
-                f.write(file_content.strip() + "\r\n")
+            file_path = base_path / file_name.strip()
+            file_path.write_text(file_content.strip() + "\r\n", encoding="utf-8")
+
+    return str(base_path)
 
 
-def _clear_repo_directory_structure() -> None:
-    for root, dirs, files in os.walk(".", topdown=False):
-        for name in files:
-            os.remove(os.path.join(root, name))
-        for name in dirs:
-            os.rmdir(os.path.join(root, name))
-
-
-R = TypeVar("R")
-
-
-def with_repo_structure_in_tmpdir(specification: str):
-    """Create and remove repo structure based on specification for testing. Use as decorator."""
-
-    def decorator(func: Callable[..., R]) -> Callable[..., R]:
-
-        def wrapper(*args, **kwargs):
-            cwd = os.getcwd()
-            tmpdir = _get_tmp_dir()
-            os.chdir(tmpdir)
-            _create_repo_directory_structure(specification)
-            try:
-                result = func(*args, **kwargs)
-            finally:
-                _clear_repo_directory_structure()
-                os.chdir(cwd)
-                _remove_tmp_dir(tmpdir)
-            return result
-
-        return wrapper
-
-    return decorator
-
-
-def _create_random_file_tree(
+def create_random_repo_structure(
     base_path: Path,
     depth: int = 3,
     dir_count: int = 5,
     file_count: int = 10,
     max_file_size: int = 1024,
-):
-    """Recursively create a directory tree with random files."""
+) -> str:
+    """Recursively create a directory tree with random files below base_path.
+
+    Returns the repo root as a string, ready to hand to a scan processor.
+    """
 
     def random_name(length: int = 8) -> str:
         return "".join(random.choices(string.ascii_letters + string.digits, k=length))
@@ -119,30 +86,4 @@ def _create_random_file_tree(
     base_path.mkdir(parents=True, exist_ok=True)
     create_dirs(base_path, depth, dir_count, file_count)
 
-
-def with_random_repo_structure_in_tmpdir(
-    depth: int = 3, dir_count: int = 5, file_count: int = 10, max_file_size: int = 1024
-):
-    """Create and remove random repo structure based on specification for testing."""
-
-    def decorator(func: Callable[..., R]) -> Callable[..., R]:
-
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            cwd = os.getcwd()
-            tmpdir = _get_tmp_dir()
-            os.chdir(tmpdir)
-            _create_random_file_tree(
-                Path(tmpdir), depth, dir_count, file_count, max_file_size
-            )
-            try:
-                result = func(*args, **kwargs)
-            finally:
-                _clear_repo_directory_structure()
-                os.chdir(cwd)
-                _remove_tmp_dir(tmpdir)
-            return result
-
-        return wrapper
-
-    return decorator
+    return str(base_path)


### PR DESCRIPTION
Closes #186.

## What changed

`with_repo_structure_in_tmpdir` / `with_random_repo_structure_in_tmpdir` are replaced by plain helpers (`create_repo_structure`, `create_random_repo_structure`) that build a tree below a caller-supplied directory — pytest's `tmp_path` — and return it. Tests pass that root explicitly into the API under test; nothing changes the process CWD anymore.

## Two latent bugs this surfaced

Making the root explicit exposed two places where scanning resolved paths against the CWD instead of the repository root. Both were masked by the tests `chdir`-ing into the repo they scanned:

- **`check_companion_files`** searched `<cwd>/<rel_dir>`. Callers now join the repo root in and pass the directory to search. `full-scan --repo-root X` previously looked for companion files under the CWD, not under `X`.
- **`skip_entry`** matched gitignore rules against the bare entry name (`ignored.md`), not the path relative to the root (`python/ignored.md`). It now passes the relative path, and `FullScanProcessor` wraps the matcher so it resolves against the root. New test: `test_succeed_gitignored_file_in_subdirectory` (verified failing without the fix).

`DiffScanProcessor` gains an optional trailing `repo_root` (default `"."`, which is what the CLI and the pre-commit hook pass paths relative to).

## Note on the issue's rationale

The issue cites `pytest-xdist` as the motivation. That part doesn't hold: xdist gives each worker its own process and runs tests sequentially within it, so a per-test `chdir`/restore is not what breaks it (xdist also isn't a dependency here). The rest of the rationale does hold — `os.chdir` before the `try` means a failure in tree setup leaves the entire session chdir'd into a directory that then gets deleted — and the explicit-root refactor was worth doing on its own, as the two bugs above show.

## Out of scope

`__main___test.py` still resolves test config files (`test_config_allow_all.yaml`) relative to the CWD, so those tests fail if pytest is invoked from elsewhere. That is a test-data-path concern, not a `chdir` one — no test mutates the CWD after this change.

## Verification

- `uv run --extra dev pytest` — 249 passed
- `uv run prek run --all-files` — all hooks pass
- `pytest` from an unrelated CWD — `full_scan_test.py`, `diff_scan_test.py`, `benchmark_test.py` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)