### PR TITLE
Build with hatchling to keep tests out of the wheel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,16 @@ demo of the tool's flagship feature. `check_companion_files` resolves companions
 by walking _below_ the matched file's directory, so a `../tests/…` companion can
 never match — relocating tests forces that rule to be dropped.
 
-The accepted cost is that setuptools ships the test modules in the wheel
-(~50 KB). Note that `[tool.setuptools.packages.find] exclude` filters _package
-names_, not files, so the existing `exclude = ["repo_structure/*_test.py"]` line
-is inert and cannot be made to work. If wheel contents ever need cleaning up,
-switch the build backend to hatchling (`hatch-vcs` replacing `setuptools-scm`),
-which can exclude files.
+Tests are kept out of the wheel at _build_ time instead of by relocating them.
+The build backend is hatchling (with `hatch-vcs` for the version), whose
+`[tool.hatch.build.targets.wheel] exclude` matches file patterns. setuptools
+could not do this: its `packages.find` exclude filters _package names_, not
+files, so the old `exclude = ["repo_structure/*_test.py"]` line was inert.
+
+Anything test-only added under `repo_structure/` must therefore match one of
+the `exclude` patterns in `pyproject.toml` — `*_test.py`, `test_lib.py`,
+`test_config_*.yaml` — or it will ship to PyPI. The sdist deliberately keeps
+the tests so downstreams can run the suite.
 
 ## Module map
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "repo-structure"
@@ -42,16 +42,18 @@ dev = [
 [project.scripts]
 repo_structure = "repo_structure.__main__:repo_structure"
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["repo_structure"]
-exclude = ["repo_structure/*_test.py"]
+[tool.hatch.version]
+source = "vcs"
 
-[tool.setuptools.package-data]
-repo_structure = ["*.json"]
+[tool.hatch.build.hooks.vcs]
+version-file = "repo_structure/_version.py"
 
-[tool.setuptools_scm]
-version_file = "repo_structure/_version.py"
+[tool.hatch.build.targets.wheel]
+packages = ["repo_structure"]
+# Tests live beside the modules they test (see CLAUDE.md); strip them from the
+# wheel here rather than relocating them. Hatchling matches file patterns,
+# which setuptools' packages.find exclude cannot do.
+exclude = ["*_test.py", "test_lib.py", "test_config_*.yaml"]
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
## Problem

Tests live beside the modules they test, which is load-bearing for this repo's `companion` self-validation rule and must stay that way. The cost was that they shipped to PyPI: the wheel contained 24 files, 10 of them test-only (`*_test.py`, `test_lib.py`, `test_config_*.yaml`).

The `exclude = ["repo_structure/*_test.py"]` line in `pyproject.toml` looked like it handled this, but `packages.find` exclude filters package *names*, not files — the line was inert. setuptools has no declarative way to drop individual modules from a package; `build_py` collects them as modules, and `exclude-package-data` only filters data files.

## Change

Switch the build backend to hatchling, with `hatch-vcs` replacing `setuptools-scm`. Hatchling's wheel target takes gitignore-style **file** patterns, which is the whole difference:

```toml
[tool.hatch.build.targets.wheel]
packages = ["repo_structure"]
exclude = ["*_test.py", "test_lib.py", "test_config_*.yaml"]
```

Tests do not move. `CLAUDE.md` is updated, since it documented shipping the tests as an accepted cost.

## Result

| | before | after |
|---|---|---|
| files in wheel | 24 (10 test-only) | **15, zero test content** |
| sdist | tests included | tests still included, deliberately |
| `config.schema.json` | needed explicit `package-data` | included automatically |
| `_version.py` | setuptools-scm | hatch-vcs, same `version` / `__version__` |

## Verification

- `uv run --extra dev pytest` — 254 passed
- `uv run prek run --all-files` — all hooks passed
- `uv build` — builds the wheel *via* the sdist, so both paths work
- Installed the wheel into a clean venv: `repo_structure --version` and `full-scan` both work

No CI change needed — `publish-to-pypi.yaml` uses `python -m build` and `pip install -e .`, both backend-agnostic. `uv.lock` is unchanged; build requirements aren't locked.

## Note for future work

Any new **test-only** file under `repo_structure/` must match one of the three exclude patterns or it will ship. This is now called out in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)