### PR TITLE
Support multi-file, directory-relative configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,9 @@ the tests so downstreams can run the suite.
 
 - `__main__.py` — click CLI: `full-scan`, `diff-scan`, `report`
 - `config.py` — YAML parsing, schema validation, template expansion
+- `config_merge.py` — flattens a `use_config` mount tree into one configuration:
+  rule-name qualification, `inherit`/`override`, collision errors. Takes the
+  document parser as a callable so `config.py` can depend on it, not vice versa
 - `models.py` — dataclasses, type aliases, rule constants
 - `errors.py` — exception hierarchy
 - `paths.py` — path normalization

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,11 @@ The build backend is hatchling (with `hatch-vcs` for the version), whose
 could not do this: its `packages.find` exclude filters _package names_, not
 files, so the old `exclude = ["repo_structure/*_test.py"]` line was inert.
 
-Anything test-only added under `repo_structure/` must therefore match one of
-the `exclude` patterns in `pyproject.toml` — `*_test.py`, `test_lib.py`,
-`test_config_*.yaml` — or it will ship to PyPI. The sdist deliberately keeps
-the tests so downstreams can run the suite.
+Anything added under `repo_structure/` that is not runtime data must therefore
+match one of the `exclude` patterns in `pyproject.toml` — `*_test.py`,
+`test_lib.py`, `test_config_*.yaml`, `repo_structure.yaml` — or it will ship to
+PyPI. The sdist deliberately keeps them so downstreams can run the suite.
+`config.schema.json` is the one data file that _should_ ship.
 
 ## Module map
 
@@ -61,11 +62,26 @@ the tests so downstreams can run the suite.
 ## Self-validation
 
 `repo_structure.yaml` describes this repository, and `full-scan` runs in CI and
-as a pre-commit hook. Its `base_structure` rule has no catch-all `allow`, so
-**adding any new file at the repo root fails the scan until you add a matching
-entry to `repo_structure.yaml`**. The same applies to new directories, which
-need a `directory_map` entry. Run `uv run repo_structure full-scan` after adding
-files.
+as a pre-commit hook. Run `uv run repo_structure full-scan` after adding files.
+
+The configuration is **split across two files**, which is this repo's demo of
+multi-file configuration the same way the `companion` rule demos companion
+files:
+
+- `repo_structure.yaml` (root) — the `base_structure` rule for repo-root files,
+  and a `use_config` entry delegating `/repo_structure/` to the file below
+- `repo_structure/repo_structure.yaml` — the `python_package` rule, including
+  the `companion` rule. Its `directory_map` keys are relative to that
+  directory, so `/` there means `/repo_structure/`
+
+So **which file to edit depends on where the new file goes**: a new file at the
+repo root needs an entry in the root config, a new module under
+`repo_structure/` needs one in the package config. Neither rule has a catch-all
+`allow`, so an unlisted file fails the scan either way. New directories need a
+`directory_map` entry in whichever config governs their parent.
+
+Note that a mounted configuration file is skipped by the scan, so
+`repo_structure/repo_structure.yaml` does not need a rule matching itself.
 
 ## Issue-driven work
 

--- a/README.md
+++ b/README.md
@@ -407,7 +407,9 @@ The root key '/' must be in the Dictionary Map. A key must start and end with a
 slash '/' and must point to a real directory in the repository.
 
 A mapped directory only requires the Structure Rules that are mapped to it, it
-**does not inherit** the rules from its parent directories.
+**does not inherit** the rules from its parent directories. (Inheriting rules
+from a parent _configuration file_ is a different thing, and is described under
+[Multiple Configuration Files](#multiple-configuration-files).)
 
 For example:
 
@@ -449,6 +451,144 @@ directory_map:
 ```
 
 The rule can
+
+## Multiple Configuration Files
+
+A repository does not have to keep all of its rules in one file. A
+`directory_map` entry can hand a directory over to another configuration file
+with `use_config`, so the team that owns a directory owns the rules for it:
+
+```yaml
+# repo_structure.yaml, at the repository root
+structure_rules:
+  base:
+    - description: "Files every repository needs"
+    - require: 'README\.md'
+  docs:
+    - description: "Documentation"
+    - allow: '.*\.md'
+directory_map:
+  /:
+    - description: "Root directory"
+    - use_rule: base
+  /frontend/:
+    - description: "Owned by the frontend team"
+    - use_config: repo_structure.yaml
+```
+
+The mounted file lives in the directory it governs, and `use_config` is resolved
+relative to that directory -- the configuration above reads
+`frontend/repo_structure.yaml`. A mounted configuration may mount further
+configurations of its own, which is how deeper subtrees are delegated.
+
+### Directories Are Relative to the Configuration File
+
+Inside a mounted configuration, `/` is the directory it was mounted at. The
+frontend team writes their file as though their directory were the repository:
+
+```yaml
+# frontend/repo_structure.yaml
+structure_rules:
+  ts_package:
+    - description: "TypeScript package"
+    - require: 'index\.ts'
+directory_map:
+  /:
+    - description: "Frontend root" # this is /frontend/
+    - use_rule: ts_package
+  /components/:
+    - description: "Components" # this is /frontend/components/
+    - use_rule: ts_package
+```
+
+A mounted configuration cannot govern anything outside the directory it was
+given: `use_config` paths and `directory_map` keys that traverse upwards with
+`..` are rejected.
+
+### Inheriting Structure Rules
+
+Rules are private to the file that defines them, so two teams may both define a
+rule called `python_package` without interfering. A configuration that wants its
+parent's rules has to say so, with an `inherit` block:
+
+```yaml
+# frontend/repo_structure.yaml
+inherit:
+  structure_rules: all # every rule of the mounting configuration
+directory_map:
+  /:
+    - description: "Frontend root"
+    - use_rule: docs # defined in the root configuration
+```
+
+`structure_rules: all` is the one-line form. To take only specific rules, list
+them instead:
+
+```yaml
+inherit:
+  structure_rules: [docs, base]
+```
+
+Inheriting does not copy a rule -- it makes the parent's rule usable under its
+own name. Change the rule in the parent and every configuration that inherits it
+follows along.
+
+Inheritance chains: a configuration offers its own rules _and_ the ones it
+inherited to any configuration it mounts.
+
+### Overriding an Inherited Rule
+
+Redefining a rule you inherited has to be deliberate. Name it in
+`inherit.override`:
+
+```yaml
+# frontend/repo_structure.yaml
+inherit:
+  structure_rules: all
+  override: [docs]
+structure_rules:
+  docs:
+    - description: "Frontend flavour of docs"
+    - require: 'GUIDE\.md'
+directory_map:
+  /:
+    - description: "Frontend root"
+    - use_rule: docs # the frontend's docs, not the root's
+```
+
+The override applies only to the configuration that declares it. The root
+configuration -- and any other team -- keeps using the original rule.
+
+### Collisions Are Errors
+
+Anything ambiguous about which definition wins fails the configuration load
+rather than being resolved silently:
+
+| Situation                                                                         | Why it is rejected                                      |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| A rule redefines an inherited name without `inherit.override`                     | It is unclear whether shadowing was intended            |
+| `inherit.override` names a rule that is not inherited                             | There is nothing to override                            |
+| `inherit.structure_rules` names a rule the parent does not define                 | The rule cannot be resolved                             |
+| Two configurations map the same directory                                         | Two owners for one directory                            |
+| A `directory_map` key or `use_config` path traverses upwards with `..`            | A configuration would govern a subtree it was not given |
+| The same configuration file is reached from two mounts                            | One file would describe two directories                 |
+| One `directory_map` entry combines `use_config` with `use_rule` or `use_template` | The directory would be governed twice                   |
+| A directory both maps rules and mounts a configuration                            | Same as above, spelled across two entries               |
+| A top-level configuration declares `inherit`                                      | There is no parent configuration to inherit from        |
+
+### Reading a Multi-File Configuration
+
+`repo_structure report` names the file each rule comes from, which is what tells
+two same-named rules apart:
+
+```markdown
+### Rule: `docs` {#rule-frontend-repo_structure-yaml-docs}
+
+**Defined in:** `frontend/repo_structure.yaml`
+```
+
+Every mounted configuration file is excluded from validation, the same way the
+top-level configuration file always has been.
 
 ## System Requirements
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ You can control:
 - Mapping directory structure rules to specific directories (`directory_map`)
 - Reusing directory structure rules recursively (`use_rule` in `structure_rules`)
 - Template for structures with patterns (`templates`)
+- Splitting the configuration across directories (`use_config`, `inherit`)
 
-Here is an example file that showcases all the supported features:
-[example YAML](repo_structure.yaml)
+This repository validates itself, so its own configuration is the worked
+example. It is split across two files, which is the `use_config` feature in
+use: [the root configuration](repo_structure.yaml) delegates the package
+directory to [the package's own configuration](repo_structure/repo_structure.yaml).
 
 Cross-platform support for Windows, macOS, and Linux.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,14 @@ packages = ["repo_structure"]
 # Tests live beside the modules they test (see CLAUDE.md); strip them from the
 # wheel here rather than relocating them. Hatchling matches file patterns,
 # which setuptools' packages.find exclude cannot do.
-exclude = ["*_test.py", "test_lib.py", "test_config_*.yaml"]
+# repo_structure.yaml describes this directory for the tool's own self-scan and
+# is not runtime data, so it stays out of the wheel too.
+exclude = [
+    "*_test.py",
+    "test_lib.py",
+    "test_config_*.yaml",
+    "repo_structure.yaml",
+]
 
 [tool.coverage.run]
 omit = [

--- a/repo_structure.yaml
+++ b/repo_structure.yaml
@@ -15,30 +15,17 @@ structure_rules:
     - require: 'renovate\.json'
     - require: '\.python-version'
     - require: '\.pylintrc'
-  python_package:
-    - description: "Standard Python package structure with modules, tests, and configuration files"
-    - require: '__main__\.py'
-    - require: '__init__\.py'
-    # Specify files that don't need a companion first
-    - allow: '_version\.py'
-    # TODO: Add test for the schema
-    - allow: 'schema\.py'
-    - allow: 'test_lib\.py'
-    - allow: '.*_test\.py'
-    # Specify the companion
-    - allow: '(?P<base>.*)\.py'
-      companion:
-        - require: '{{base}}_test\.py'
-    - require: 'config\.schema\.json'
-    - require: 'test_config_.*\.yaml'
 
 directory_map:
   /:
     - description: "Root directory containing project documentation, configuration files, and main project structure"
     - use_rule: base_structure
+  # Delegated to the package's own configuration - see repo_structure/repo_structure.yaml.
+  # This is the repo's demo of multi-file configuration, the same way the
+  # companion rule below demos companion files.
   /repo_structure/:
-    - description: "Main Python package directory containing the core application logic and modules"
-    - use_rule: python_package
+    - description: "Main Python package directory, governed by its own configuration"
+    - use_config: repo_structure.yaml
   /.github/:
     - description: "GitHub-specific configuration and workflow files - ignored from structure validation"
     - use_rule: ignore

--- a/repo_structure/config.py
+++ b/repo_structure/config.py
@@ -4,43 +4,27 @@ import copy
 import logging
 import re
 import warnings
-from dataclasses import dataclass, field
 from typing import NamedTuple, TextIO, Any
 
 from ruamel import yaml as YAML
 from jsonschema import validate, ValidationError, SchemaError
 
+from .config_merge import build_config_tree
 from .errors import ConfigurationParseError, StructureRuleError, TemplateError
 from .models import (
+    ConfigurationData,
+    InheritSpec,
+    ParsedDocument,
     RepoEntry,
     DirectoryMap,
     StructureRuleList,
     StructureRuleMap,
     BUILTIN_DIRECTORY_RULES,
 )
-from .paths import map_dir_to_rel_dir
+from .paths import map_dir_to_rel_dir, relative_to_root
 from .schema import get_json_schema
 
 _LOGGER = logging.getLogger(__name__)
-
-
-@dataclass
-class ConfigurationData:
-    """Stores configuration data."""
-
-    structure_rules: StructureRuleMap = field(default_factory=dict)
-    directory_map: DirectoryMap = field(default_factory=dict)
-    configuration_file_name: str = ""
-    structure_rule_descriptions: dict[str, str] = field(default_factory=dict)
-    directory_descriptions: dict[str, str] = field(default_factory=dict)
-
-    def get_structure_rule_description(self, rule_name: str) -> str:
-        """Get the description for a structure rule."""
-        return self.structure_rule_descriptions.get(rule_name, "")
-
-    def get_directory_description(self, directory: str) -> str:
-        """Get the description for a directory."""
-        return self.directory_descriptions.get(directory, "")
 
 
 class Configuration:
@@ -132,22 +116,14 @@ class Configuration:
         if verbose:
             logging.getLogger(__package__).setLevel(logging.DEBUG)
 
-        yaml_dict = self._load(config_file, param1_is_yaml_string)
-        self._validate_schema(yaml_dict, schema)
+        if param1_is_yaml_string:
+            self.config = _build_from_yaml_string(config_file, schema)
+        else:
+            self.config = build_config_tree(
+                config_file, lambda path: load_document(path, schema)
+            )
 
-        _LOGGER.debug("Parsing configuration data")
-        structure_rules, structure_rule_descriptions = self._parse_rules(yaml_dict)
-        directory_map, directory_descriptions = self._parse_directory_map(yaml_dict)
-        self.config = ConfigurationData(
-            structure_rules=structure_rules,
-            directory_map=directory_map,
-            structure_rule_descriptions=structure_rule_descriptions,
-            directory_descriptions=directory_descriptions,
-        )
-
-        self._expand_templates(yaml_dict)
         self._validate_cross_references()
-        self._register_configuration_file(config_file, param1_is_yaml_string)
 
         _LOGGER.debug(
             "Structure rules count: %d, Directory map count: %d",
@@ -155,69 +131,6 @@ class Configuration:
             len(self.config.directory_map),
         )
         _LOGGER.debug("Configuration parsed successfully")
-
-    @staticmethod
-    def _load(config_file: str, param1_is_yaml_string: bool) -> dict:
-        """Read the YAML source into a dictionary."""
-        _LOGGER.debug("Loading configuration")
-        if param1_is_yaml_string:
-            yaml_dict = _load_repo_structure_yamls(config_file)
-        else:
-            yaml_dict = _load_repo_structure_yaml(config_file)
-
-        if not yaml_dict:
-            source = "yaml string" if param1_is_yaml_string else config_file
-            raise ConfigurationParseError(
-                f"Configuration is empty or could not be parsed: {source}"
-            )
-        return yaml_dict
-
-    @staticmethod
-    def _validate_schema(yaml_dict: dict, schema: dict[Any, Any] | None) -> None:
-        """Validate the raw YAML against the JSON schema."""
-        if not schema:
-            schema = get_json_schema()
-
-        try:
-            validate(instance=yaml_dict, schema=schema)
-        except ValidationError as e:
-            raise ConfigurationParseError(f"Bad config: {e.message}") from e
-        except SchemaError as e:
-            raise ConfigurationParseError(f"Bad schema: {e.message}") from e
-        _LOGGER.debug("Configuration validated successfully")
-
-    @staticmethod
-    def _parse_rules(yaml_dict: dict) -> tuple[StructureRuleMap, dict[str, str]]:
-        """Parse the ``structure_rules`` section into rules and descriptions."""
-        return _parse_structure_rules(yaml_dict.get("structure_rules", {}))
-
-    @staticmethod
-    def _parse_directory_map(yaml_dict: dict) -> tuple[DirectoryMap, dict[str, str]]:
-        """Parse the ``directory_map`` section into mappings and descriptions."""
-        return _build_directory_map(yaml_dict.get("directory_map", {}))
-
-    def _expand_templates(self, yaml_dict: dict) -> None:
-        """Expand templates in-place, adding structure rules to the directory map."""
-        _parse_templates_to_configuration(
-            yaml_dict.get("templates", {}),
-            yaml_dict.get("directory_map", {}),
-            self,
-        )
-
-    def _register_configuration_file(
-        self, config_file: str, param1_is_yaml_string: bool
-    ) -> None:
-        """Record the config file name so scans can account for the file itself."""
-        if param1_is_yaml_string:
-            return
-
-        if config_file in self.config.structure_rules:
-            raise ConfigurationParseError(
-                f"Conflicting Structure rule for {config_file}"
-                "- do not add the config manually."
-            )
-
-        self.config.configuration_file_name = config_file
 
     def _validate_cross_references(self):
         """Ensure every rule referenced by the directory map exists."""
@@ -254,8 +167,35 @@ class Configuration:
 
     @property
     def configuration_file_name(self) -> str:
-        """Property for configuration file name."""
+        """Property for the top-level configuration file name."""
         return self.config.configuration_file_name
+
+    @property
+    def configuration_file_names(self) -> set[str]:
+        """Property for every configuration file that took part in the load.
+
+        Holds the top-level configuration file as it was passed in, plus every
+        mounted configuration as a repository-root relative path.
+        """
+        return self.config.configuration_file_names
+
+    @property
+    def rule_origins(self) -> dict[str, str]:
+        """Property mapping each structure rule to the file that defined it."""
+        return self.config.rule_origins
+
+    def configuration_file_names_for(self, repo_root: str) -> set[str]:
+        """Names a scan of ``repo_root`` should recognise as configuration files.
+
+        Mounted configurations are already recorded relative to the repository
+        root. The top-level configuration is not: it is whatever path the caller
+        passed in, so it is additionally offered relative to ``repo_root``.
+        """
+        names = set(self.config.configuration_file_names)
+        root_relative = relative_to_root(self.config.configuration_file_name, repo_root)
+        if root_relative:
+            names.add(root_relative)
+        return names
 
     @property
     def structure_rule_descriptions(self) -> dict[str, str]:
@@ -266,6 +206,123 @@ class Configuration:
     def directory_descriptions(self) -> dict[str, str]:
         """Property for directory descriptions."""
         return self.config.directory_descriptions
+
+
+def load_document(path: str, schema: dict[Any, Any] | None = None) -> ParsedDocument:
+    """Read and parse a single configuration file.
+
+    This is the per-file half of configuration loading: it knows nothing about
+    mounted configurations beyond recording them in
+    :attr:`ParsedDocument.mounts`. Combining documents is
+    ``config_merge``'s job.
+
+    Args:
+        path: Filesystem path to the YAML configuration file.
+        schema: Optional JSON schema to validate the YAML against.
+    """
+    yaml_dict = _load_repo_structure_yaml(path)
+    if not yaml_dict:
+        raise ConfigurationParseError(
+            f"Configuration is empty or could not be parsed: {path}"
+        )
+    return parse_document(yaml_dict, schema)
+
+
+def parse_document(
+    yaml_dict: dict, schema: dict[Any, Any] | None = None
+) -> ParsedDocument:
+    """Validate and parse one already-loaded configuration document.
+
+    Args:
+        yaml_dict: The raw YAML document.
+        schema: Optional JSON schema to validate the document against.
+    """
+    _validate_schema(yaml_dict, schema)
+
+    _LOGGER.debug("Parsing configuration data")
+    directory_map_yaml = yaml_dict.get("directory_map", {})
+    structure_rules, rule_descriptions = _parse_structure_rules(
+        yaml_dict.get("structure_rules", {})
+    )
+    directory_map, directory_descriptions, mounts = _build_directory_map(
+        directory_map_yaml
+    )
+
+    document = ParsedDocument(
+        structure_rules=structure_rules,
+        structure_rule_descriptions=rule_descriptions,
+        directory_map=directory_map,
+        directory_descriptions=directory_descriptions,
+        mounts=mounts,
+        inherit=_parse_inherit(yaml_dict.get("inherit", {})),
+    )
+    _parse_templates_to_document(
+        yaml_dict.get("templates", {}), directory_map_yaml, document
+    )
+    return document
+
+
+def _validate_schema(yaml_dict: dict, schema: dict[Any, Any] | None) -> None:
+    """Validate the raw YAML against the JSON schema."""
+    if not schema:
+        schema = get_json_schema()
+
+    try:
+        validate(instance=yaml_dict, schema=schema)
+    except ValidationError as e:
+        raise ConfigurationParseError(f"Bad config: {e.message}") from e
+    except SchemaError as e:
+        raise ConfigurationParseError(f"Bad schema: {e.message}") from e
+    _LOGGER.debug("Configuration validated successfully")
+
+
+def _parse_inherit(inherit_yaml: dict) -> InheritSpec:
+    """Parse the ``inherit`` section of a mounted configuration."""
+    structure_rules = inherit_yaml.get("structure_rules")
+    override = list(inherit_yaml.get("override", []))
+
+    if structure_rules is None and override:
+        raise ConfigurationParseError(
+            "'inherit.override' requires 'inherit.structure_rules' -- "
+            f"nothing is inherited that {', '.join(sorted(override))} could override"
+        )
+
+    return InheritSpec(structure_rules=structure_rules, override=override)
+
+
+def _build_from_yaml_string(
+    yaml_string: str, schema: dict[Any, Any] | None
+) -> ConfigurationData:
+    """Build configuration data from raw YAML text.
+
+    A YAML string has no directory to resolve mounted configuration paths
+    against and no parent to inherit from, so both are rejected here.
+    """
+    _LOGGER.debug("Loading configuration")
+    yaml_dict = _load_repo_structure_yamls(yaml_string)
+    if not yaml_dict:
+        raise ConfigurationParseError(
+            "Configuration is empty or could not be parsed: yaml string"
+        )
+
+    document = parse_document(yaml_dict, schema)
+    if document.mounts:
+        raise ConfigurationParseError(
+            "'use_config' is only supported when loading from a file, "
+            "since the mounted path is resolved relative to the configuration"
+        )
+    if document.inherit.structure_rules is not None:
+        raise ConfigurationParseError(
+            "'inherit' is only valid in a configuration mounted through "
+            "'use_config' -- there is no parent configuration to inherit from"
+        )
+
+    return ConfigurationData(
+        structure_rules=document.structure_rules,
+        directory_map=document.directory_map,
+        structure_rule_descriptions=document.structure_rule_descriptions,
+        directory_descriptions=document.directory_descriptions,
+    )
 
 
 def _load_repo_structure_yaml(filename: str) -> dict:
@@ -437,7 +494,7 @@ def _expand_template_entry(
 
 
 def _parse_use_template(
-    dir_map_yaml: dict, directory: str, templates_yaml: dict, config: Configuration
+    dir_map_yaml: dict, directory: str, templates_yaml: dict, document: ParsedDocument
 ):
     if "use_template" not in dir_map_yaml:
         return
@@ -476,16 +533,28 @@ def _parse_use_template(
         f"__template_rule_{map_dir_to_rel_dir(directory)}_"
         f"{dir_map_yaml['use_template']}"
     )
-    config.add_template_rule(directory, template_rule_name, structure_rule_list)
+    document.structure_rules[template_rule_name] = structure_rule_list
+    document.directory_map.setdefault(directory, []).append(template_rule_name)
 
 
 def _build_directory_map(
     directory_map_yaml: dict,
-) -> tuple[DirectoryMap, dict[str, str]]:
+) -> tuple[DirectoryMap, dict[str, str], dict[str, str]]:
+    """Parse the ``directory_map`` section.
 
-    def _parse_use_rule(rule: dict, dir_map: list[str]) -> None:
-        if rule.keys() == {"use_rule"}:
-            dir_map.append(rule["use_rule"])
+    Returns the rules mapped to each directory, the directory descriptions and
+    the configurations mounted through ``use_config``, keyed by mount directory.
+    """
+
+    def _parse_use_config(rule: dict, directory: str, mounts: dict[str, str]) -> None:
+        if rule.keys() != {"use_config"}:
+            return
+        if directory in mounts:
+            raise ConfigurationParseError(
+                f"Directory mapping '{directory}' mounts more than one "
+                "configuration through 'use_config'"
+            )
+        mounts[directory] = rule["use_config"]
 
     def _extract_description(value_list: list) -> str:
         """Extract and validate description from directory map entry."""
@@ -503,22 +572,24 @@ def _build_directory_map(
 
     mapping: DirectoryMap = {}
     descriptions: dict[str, str] = {}
+    mounts: dict[str, str] = {}
 
     for directory, value in directory_map_yaml.items():
         description = _extract_description(value)
         descriptions[directory] = description
 
         for r in value[1:]:  # Skip the description at index 0
-            if mapping.get(directory) is None:
-                mapping[directory] = []
-            _parse_use_rule(r, mapping[directory])
+            if r.keys() == {"use_rule"}:
+                mapping.setdefault(directory, []).append(r["use_rule"])
+            else:
+                _parse_use_config(r, directory, mounts)
 
-    return mapping, descriptions
+    return mapping, descriptions, mounts
 
 
-def _parse_templates_to_configuration(
-    templates_yaml: dict, directory_map_yaml: dict, config: Configuration
+def _parse_templates_to_document(
+    templates_yaml: dict, directory_map_yaml: dict, document: ParsedDocument
 ) -> None:
     for directory, value in directory_map_yaml.items():
         for use_map in value:
-            _parse_use_template(use_map, directory, templates_yaml, config)
+            _parse_use_template(use_map, directory, templates_yaml, document)

--- a/repo_structure/config.schema.json
+++ b/repo_structure/config.schema.json
@@ -60,6 +60,7 @@
         "properties": {
           "use_rule": { "type": "string" },
           "use_template": { "type": "string" },
+          "use_config": { "type": "string" },
           "parameters": {
             "type": "object",
             "additionalProperties": {
@@ -71,7 +72,8 @@
         "additionalProperties": false,
         "anyOf": [
           { "required": ["use_rule"] },
-          { "required": ["use_template", "parameters"] }
+          { "required": ["use_template", "parameters"] },
+          { "required": ["use_config"] }
         ],
         "dependentSchemas": {
           "use_rule": {
@@ -82,6 +84,13 @@
           "use_template": {
             "properties": {
               "parameters": { "type": "object" }
+            }
+          },
+          "use_config": {
+            "properties": {
+              "use_rule": { "type": "null" },
+              "use_template": { "type": "null" },
+              "parameters": { "type": "null" }
             }
           }
         }
@@ -95,7 +104,7 @@
       "description": "Contains named structure rules specifying allowed and required directory entries and are mapped to directories through the directory_map",
       "type": "object",
       "patternProperties": {
-        "^(?!__).*": { "$ref": "#/$defs/directory_entries" }
+        "^(?!__)(?!.*::).*$": { "$ref": "#/$defs/directory_entries" }
       },
       "additionalProperties": false
     },
@@ -103,7 +112,26 @@
       "description": "Contains named templates that are expanded by usage in the directory_map into structure rules",
       "type": "object",
       "patternProperties": {
-        "^(?!__).*": { "$ref": "#/$defs/directory_entries" }
+        "^(?!__)(?!.*::).*$": { "$ref": "#/$defs/directory_entries" }
+      },
+      "additionalProperties": false
+    },
+    "inherit": {
+      "description": "Declares which structure rules this configuration takes over from the configuration that mounted it through use_config",
+      "type": "object",
+      "properties": {
+        "structure_rules": {
+          "description": "Either the string 'all' to inherit every structure rule of the parent, or an explicit list of rule names",
+          "anyOf": [
+            { "const": "all" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
+        },
+        "override": {
+          "description": "Names of inherited structure rules this configuration deliberately redefines",
+          "type": "array",
+          "items": { "type": "string" }
+        }
       },
       "additionalProperties": false
     },
@@ -116,5 +144,9 @@
     }
   },
   "required": ["directory_map"],
-  "anyOf": [{ "required": ["structure_rules"] }, { "required": ["templates"] }]
+  "anyOf": [
+    { "required": ["structure_rules"] },
+    { "required": ["templates"] },
+    { "required": ["inherit"] }
+  ]
 }

--- a/repo_structure/config_merge.py
+++ b/repo_structure/config_merge.py
@@ -1,0 +1,339 @@
+"""Combining several configuration documents into one flat configuration.
+
+A repository can split its configuration across directories: a ``directory_map``
+entry mounts another configuration file with ``use_config``, and that file
+describes its own subtree using paths relative to itself. This module walks that
+mount tree and flattens it into a single :class:`ConfigurationData`, so nothing
+downstream of ``Configuration`` has to know that more than one file was read.
+
+Two ideas carry the whole merge:
+
+*Qualification.* Rules from a mounted configuration are stored under
+``"<config path>::<rule name>"``, so two teams may both define ``python_package``
+without ever colliding. Rules of the top-level configuration keep their bare
+names, which is what makes a single-file configuration merge to exactly what it
+parsed to.
+
+*Inheritance is aliasing.* ``inherit.structure_rules`` does not copy a parent
+rule -- it only makes the parent's qualified name reachable under its bare name
+inside the child. Redefining an inherited rule therefore has to be spelled out
+in ``inherit.override``; anything else is reported as a collision.
+"""
+
+import logging
+from pathlib import Path, PurePosixPath
+from typing import Callable
+
+from .errors import ConfigurationParseError
+from .models import (
+    ConfigurationData,
+    InheritSpec,
+    ParsedDocument,
+    StructureRuleList,
+)
+from .paths import (
+    join_path_normalized,
+    map_dir_to_rel_dir,
+    normalize_path,
+    rel_dir_to_map_dir,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+QUALIFIER = "::"
+"""Separates a configuration path from a rule name in a qualified rule name."""
+
+DocumentLoader = Callable[[str], ParsedDocument]
+"""Reads and parses one configuration file. Injected so that this module stays
+independent of the parser -- see ``config.load_document``."""
+
+
+def qualify(config_path: str, rule_name: str) -> str:
+    """Build the merged-namespace name of a rule owned by a mounted config."""
+    return f"{config_path}{QUALIFIER}{rule_name}"
+
+
+def unqualify(rule_name: str) -> str:
+    """Return the rule name as written in its own configuration file.
+
+    Bare names are returned unchanged, so this is safe to call on any rule name
+    taken from a merged configuration.
+    """
+    return rule_name.rsplit(QUALIFIER, 1)[-1]
+
+
+def rebase_map_dir(mount_dir: str, child_map_dir: str) -> str:
+    """Translate a mounted config's directory into the repository's namespace.
+
+    ``child_map_dir`` is relative to the mounted configuration, where ``/`` is
+    the directory the configuration was mounted at.
+    """
+    if child_map_dir == "/":
+        return mount_dir
+
+    return rel_dir_to_map_dir(
+        join_path_normalized(
+            map_dir_to_rel_dir(mount_dir), map_dir_to_rel_dir(child_map_dir)
+        )
+    )
+
+
+def build_config_tree(root_config_path: str, load: DocumentLoader) -> ConfigurationData:
+    """Load a configuration file and everything it mounts, as one configuration.
+
+    Args:
+        root_config_path: Path to the top-level configuration file.
+        load: Reads and parses a single configuration file.
+
+    Exceptions:
+        ConfigurationParseError: Raised for any collision between the
+            participating configurations -- see the module docstring.
+    """
+    return _TreeMerger(load).build(root_config_path)
+
+
+class _TreeMerger:  # pylint: disable=too-few-public-methods
+    """Walks the mount tree, accumulating one flat ConfigurationData.
+
+    A class rather than a function because the walk carries state across the
+    recursion: the accumulated configuration and the set of files already
+    mounted.
+    """
+
+    def __init__(self, load: DocumentLoader):
+        self._load = load
+        self._data = ConfigurationData()
+        # Resolved config path -> the directory it was first mounted at. Doubles
+        # as the guard against mount cycles and against mounting twice.
+        self._visited: dict[str, str] = {}
+
+    def build(self, root_config_path: str) -> ConfigurationData:
+        """Merge the configuration at ``root_config_path`` and its mounts."""
+        self._data.configuration_file_name = root_config_path
+        self._data.configuration_file_names.add(normalize_path(root_config_path))
+
+        self._merge(root_config_path, None, "/", {})
+
+        if root_config_path in self._data.structure_rules:
+            raise ConfigurationParseError(
+                f"Conflicting Structure rule for {root_config_path}"
+                "- do not add the config manually."
+            )
+        return self._data
+
+    def _merge(
+        self,
+        fs_path: str,
+        rel_path: str | None,
+        mount_dir: str,
+        exported: dict[str, str],
+    ) -> None:
+        """Merge one configuration file and, recursively, the ones it mounts.
+
+        Args:
+            fs_path: Path the configuration is read from.
+            rel_path: The configuration's path relative to the repository root,
+                or None for the top-level configuration, whose rules stay
+                unqualified.
+            mount_dir: Directory this configuration's ``directory_map`` is
+                relative to.
+            exported: Rule names the mounting configuration offers for
+                inheritance, mapped to their qualified names.
+        """
+        self._mark_visited(fs_path, mount_dir)
+
+        _LOGGER.debug("Merging configuration '%s' mounted at '%s'", fs_path, mount_dir)
+        document = self._load(fs_path)
+
+        if rel_path is None and document.inherit.structure_rules is not None:
+            raise ConfigurationParseError(
+                f"Configuration '{fs_path}' declares 'inherit', but it is not "
+                "mounted through 'use_config' and so has no parent to inherit from"
+            )
+
+        resolution = _resolve_rule_names(document, rel_path, exported, fs_path)
+        self._register_rules(document, resolution, rel_path or fs_path)
+        self._register_directory_map(document, resolution, mount_dir, fs_path)
+        self._mount_children(document, fs_path, mount_dir, _exportable(resolution))
+
+    def _mark_visited(self, fs_path: str, mount_dir: str) -> None:
+        identity = str(Path(fs_path).resolve())
+        previous_mount = self._visited.get(identity)
+        if previous_mount is not None:
+            raise ConfigurationParseError(
+                f"Configuration '{fs_path}' is mounted more than once "
+                f"(already mounted at '{previous_mount}', now at '{mount_dir}')"
+            )
+        self._visited[identity] = mount_dir
+
+    def _register_rules(
+        self, document: ParsedDocument, resolution: dict[str, str], origin: str
+    ) -> None:
+        for name, entries in document.structure_rules.items():
+            qualified = resolution[name]
+            _rewrite_use_rules(entries, resolution)
+            self._data.structure_rules[qualified] = entries
+            self._data.structure_rule_descriptions[qualified] = (
+                document.structure_rule_descriptions.get(name, "")
+            )
+            self._data.rule_origins[qualified] = origin
+
+    def _register_directory_map(
+        self,
+        document: ParsedDocument,
+        resolution: dict[str, str],
+        mount_dir: str,
+        fs_path: str,
+    ) -> None:
+        for child_map_dir, description in document.directory_descriptions.items():
+            self._data.directory_descriptions[
+                rebase_map_dir(mount_dir, child_map_dir)
+            ] = description
+
+        for child_map_dir, rules in document.directory_map.items():
+            _validate_map_dir_stays_below(child_map_dir, fs_path)
+            if child_map_dir in document.mounts:
+                raise ConfigurationParseError(
+                    f"Directory mapping '{child_map_dir}' in '{fs_path}' both maps "
+                    "structure rules and mounts a configuration through 'use_config'"
+                )
+
+            target = rebase_map_dir(mount_dir, child_map_dir)
+            if target in self._data.directory_map:
+                raise ConfigurationParseError(
+                    f"Directory mapping '{target}' is claimed by more than one "
+                    f"configuration -- '{fs_path}' maps it as '{child_map_dir}'"
+                )
+            self._data.directory_map[target] = [
+                resolution.get(rule, rule) for rule in rules
+            ]
+
+    def _mount_children(
+        self,
+        document: ParsedDocument,
+        fs_path: str,
+        mount_dir: str,
+        exported: dict[str, str],
+    ) -> None:
+        parent_dir = str(Path(fs_path).parent)
+        for child_map_dir, child_config in document.mounts.items():
+            _validate_mounted_path(child_config, child_map_dir, fs_path)
+
+            mount_target = rebase_map_dir(mount_dir, child_map_dir)
+            child_rel_dir = map_dir_to_rel_dir(child_map_dir)
+            child_fs_path = join_path_normalized(
+                parent_dir, child_rel_dir, child_config
+            )
+            child_rel_path = join_path_normalized(
+                map_dir_to_rel_dir(mount_target), child_config
+            )
+
+            if not Path(child_fs_path).is_file():
+                raise ConfigurationParseError(
+                    f"Directory mapping '{child_map_dir}' in '{fs_path}' mounts "
+                    f"'{child_config}', but '{child_fs_path}' does not exist"
+                )
+
+            self._data.configuration_file_names.add(child_rel_path)
+            self._merge(child_fs_path, child_rel_path, mount_target, exported)
+
+
+def _resolve_rule_names(
+    document: ParsedDocument,
+    rel_path: str | None,
+    exported: dict[str, str],
+    fs_path: str,
+) -> dict[str, str]:
+    """Map every rule name this document may use to its merged-namespace name."""
+    inherited = _inherited_names(document.inherit, exported, fs_path)
+    override = set(document.inherit.override)
+
+    unknown_override = sorted(override - set(inherited))
+    if unknown_override:
+        raise ConfigurationParseError(
+            f"'inherit.override' in '{fs_path}' names structure rules that are "
+            f"not inherited: {', '.join(unknown_override)}"
+        )
+
+    clashes = sorted(
+        name
+        for name in document.structure_rules
+        if name in inherited and name not in override
+    )
+    if clashes:
+        raise ConfigurationParseError(
+            f"Structure rules in '{fs_path}' collide with inherited rules of the "
+            f"same name: {', '.join(clashes)}. Add them to 'inherit.override' to "
+            "redefine them deliberately."
+        )
+
+    resolution = dict(inherited)
+    for name in document.structure_rules:
+        resolution[name] = qualify(rel_path, name) if rel_path else name
+    return resolution
+
+
+def _inherited_names(
+    inherit: InheritSpec, exported: dict[str, str], fs_path: str
+) -> dict[str, str]:
+    """Resolve the ``inherit.structure_rules`` request against what is on offer."""
+    if inherit.structure_rules is None:
+        return {}
+
+    if inherit.inherits_everything:
+        return dict(exported)
+
+    requested = list(inherit.structure_rules)
+    missing = sorted(name for name in requested if name not in exported)
+    if missing:
+        raise ConfigurationParseError(
+            f"'inherit.structure_rules' in '{fs_path}' names structure rules the "
+            f"mounting configuration does not define: {', '.join(missing)}"
+        )
+    return {name: exported[name] for name in requested}
+
+
+def _exportable(resolution: dict[str, str]) -> dict[str, str]:
+    """Drop generated rules, which are not meaningful to inherit."""
+    return {
+        name: qualified
+        for name, qualified in resolution.items()
+        if not name.startswith("__")
+    }
+
+
+def _rewrite_use_rules(entries: StructureRuleList, resolution: dict[str, str]) -> None:
+    """Point every ``use_rule`` at its merged-namespace name, in place.
+
+    Entries come straight out of the parser and belong to this document alone,
+    so rewriting them is not visible anywhere else.
+    """
+    for entry in entries:
+        if entry.use_rule:
+            entry.use_rule = resolution.get(entry.use_rule, entry.use_rule)
+        _rewrite_use_rules(entry.if_exists, resolution)
+        _rewrite_use_rules(entry.companion, resolution)
+
+
+def _validate_mounted_path(child_config: str, child_map_dir: str, fs_path: str) -> None:
+    """Reject mounts that would reach outside the directory they apply to."""
+    path = PurePosixPath(normalize_path(child_config))
+    if path.is_absolute() or ".." in path.parts:
+        raise ConfigurationParseError(
+            f"'use_config' for '{child_map_dir}' in '{fs_path}' must be a relative "
+            f"path below that directory, got '{child_config}'"
+        )
+    _validate_map_dir_stays_below(child_map_dir, fs_path)
+
+
+def _validate_map_dir_stays_below(map_dir: str, fs_path: str) -> None:
+    """Reject a directory mapping that climbs out of the configuration's subtree.
+
+    A mounted configuration owns the directory it was mounted at, so a mapping
+    that traverses upwards would let it govern a subtree it was not given.
+    """
+    if ".." in map_dir_to_rel_dir(map_dir).split("/"):
+        raise ConfigurationParseError(
+            f"Directory mapping '{map_dir}' in '{fs_path}' must not traverse "
+            "upwards with '..'"
+        )

--- a/repo_structure/config_merge_test.py
+++ b/repo_structure/config_merge_test.py
@@ -1,0 +1,758 @@
+"""Tests for merging directory-relative configuration files."""
+
+# pylint: disable=too-few-public-methods
+
+from pathlib import Path
+
+import pytest
+
+from .config import Configuration
+from .config_merge import qualify, rebase_map_dir, unqualify
+from .errors import ConfigurationParseError
+from .full_scan import FullScanProcessor
+from .models import Flags
+from .test_lib import create_repo_structure
+
+ROOT_CONFIG = "repo_structure.yaml"
+
+
+def _write_configs(repo_root: str, configs: dict[str, str]) -> str:
+    """Write configuration files into a repository and return the top-level one.
+
+    Keys are paths relative to the repository root; the top-level configuration
+    is expected under :data:`ROOT_CONFIG`.
+    """
+    for rel_path, content in configs.items():
+        path = Path(repo_root) / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return str(Path(repo_root) / ROOT_CONFIG)
+
+
+_PARENT_WITH_FRONTEND = """
+structure_rules:
+  base:
+    - description: 'Root files'
+    - require: 'README\\.md'
+  docs:
+    - description: 'Parent documentation rule'
+    - allow: '.*\\.md'
+directory_map:
+  /:
+    - description: 'Root'
+    - use_rule: base
+  /frontend/:
+    - description: 'Owned by the frontend team'
+    - use_config: repo_structure.yaml
+"""
+
+
+def _build(tmp_path, configs: dict[str, str], tree: str = "") -> Configuration:
+    """Create a repository with the given tree and configurations, and load it."""
+    repo = create_repo_structure(tmp_path, tree)
+    return Configuration.from_file(_write_configs(repo, configs))
+
+
+class TestQualifiedNames:
+    """Test the qualified rule name helpers."""
+
+    def test_qualify_round_trip(self):
+        """Test that unqualify recovers the name qualify was given."""
+        qualified = qualify("frontend/repo_structure.yaml", "python_package")
+        assert qualified == "frontend/repo_structure.yaml::python_package"
+        assert unqualify(qualified) == "python_package"
+
+    def test_unqualify_leaves_plain_names_alone(self):
+        """Test that a top-level rule name survives unqualify unchanged."""
+        assert unqualify("python_package") == "python_package"
+
+
+class TestRebaseMapDir:
+    """Test translating a mounted config's directories into the repository."""
+
+    @pytest.mark.parametrize(
+        "mount_dir, child_map_dir, expected",
+        [
+            ("/frontend/", "/", "/frontend/"),
+            ("/frontend/", "/components/", "/frontend/components/"),
+            ("/frontend/", "/components/ui/", "/frontend/components/ui/"),
+            ("/", "/components/", "/components/"),
+            ("/a/b/", "/c/", "/a/b/c/"),
+        ],
+    )
+    def test_rebase_map_dir(self, mount_dir, child_map_dir, expected):
+        """Test that a mounted directory map is rebased under its mount point."""
+        assert rebase_map_dir(mount_dir, child_map_dir) == expected
+
+
+class TestMounting:
+    """Test mounting a configuration through use_config."""
+
+    def test_mounted_rules_and_directories_are_merged(self, tmp_path):
+        """Test that a mounted configuration contributes rules and mappings."""
+        config = _build(
+            tmp_path,
+            {
+                ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                "frontend/repo_structure.yaml": """
+structure_rules:
+  ts_package:
+    - description: 'TypeScript package'
+    - require: 'index\\.ts'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: ts_package
+  /components/:
+    - description: 'Components'
+    - use_rule: ts_package
+""",
+            },
+        )
+
+        mounted = "frontend/repo_structure.yaml::ts_package"
+        assert config.directory_map == {
+            "/": ["base"],
+            "/frontend/": [mounted],
+            "/frontend/components/": [mounted],
+        }
+        assert mounted in config.structure_rules
+        assert config.rule_origins[mounted] == "frontend/repo_structure.yaml"
+
+    def test_mounted_config_description_wins(self, tmp_path):
+        """Test that the mounted config describes the directory it owns."""
+        config = _build(
+            tmp_path,
+            {
+                ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                "frontend/repo_structure.yaml": """
+structure_rules:
+  ts_package:
+    - description: 'TypeScript package'
+    - require: 'index\\.ts'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: ts_package
+""",
+            },
+        )
+        assert config.directory_descriptions["/frontend/"] == "Frontend root"
+
+    def test_sibling_configs_may_share_rule_names(self, tmp_path):
+        """Test that two mounted configs can define the same rule name."""
+        same_rule = """
+structure_rules:
+  package:
+    - description: 'A package'
+    - require: 'main\\.py'
+directory_map:
+  /:
+    - description: 'Team root'
+    - use_rule: package
+"""
+        config = _build(
+            tmp_path,
+            {
+                ROOT_CONFIG: """
+structure_rules:
+  base:
+    - description: 'Root files'
+    - require: 'README\\.md'
+directory_map:
+  /:
+    - description: 'Root'
+    - use_rule: base
+  /frontend/:
+    - description: 'Frontend'
+    - use_config: repo_structure.yaml
+  /backend/:
+    - description: 'Backend'
+    - use_config: repo_structure.yaml
+""",
+                "frontend/repo_structure.yaml": same_rule,
+                "backend/repo_structure.yaml": same_rule,
+            },
+        )
+
+        assert config.directory_map["/frontend/"] == [
+            "frontend/repo_structure.yaml::package"
+        ]
+        assert config.directory_map["/backend/"] == [
+            "backend/repo_structure.yaml::package"
+        ]
+
+    def test_recursive_use_rule_is_rewritten(self, tmp_path):
+        """Test that recursion inside a mounted rule points at the merged name."""
+        config = _build(
+            tmp_path,
+            {
+                ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                "frontend/repo_structure.yaml": """
+structure_rules:
+  nested:
+    - description: 'Recursive rule'
+    - require: 'index\\.ts'
+    - allow: '.*/'
+      use_rule: nested
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: nested
+""",
+            },
+        )
+
+        qualified = "frontend/repo_structure.yaml::nested"
+        recursion = [e for e in config.structure_rules[qualified] if e.use_rule]
+        assert [e.use_rule for e in recursion] == [qualified]
+
+    def test_nested_mounts(self, tmp_path):
+        """Test that a mounted configuration can mount another one."""
+        config = _build(
+            tmp_path,
+            {
+                ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                "frontend/repo_structure.yaml": """
+structure_rules:
+  ts_package:
+    - description: 'TypeScript package'
+    - require: 'index\\.ts'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: ts_package
+  /ui/:
+    - description: 'Owned by the design system team'
+    - use_config: repo_structure.yaml
+""",
+                "frontend/ui/repo_structure.yaml": """
+structure_rules:
+  widgets:
+    - description: 'Widgets'
+    - require: 'button\\.ts'
+directory_map:
+  /:
+    - description: 'UI root'
+    - use_rule: widgets
+""",
+            },
+        )
+
+        assert config.directory_map["/frontend/ui/"] == [
+            "frontend/ui/repo_structure.yaml::widgets"
+        ]
+
+
+class TestInheritance:
+    """Test inheriting structure rules from the mounting configuration."""
+
+    def test_inherit_all(self, tmp_path):
+        """Test that 'structure_rules: all' makes every parent rule usable."""
+        config = _build(
+            tmp_path,
+            {
+                ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                "frontend/repo_structure.yaml": """
+inherit:
+  structure_rules: all
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: docs
+""",
+            },
+        )
+
+        # Inheriting aliases the parent's rule rather than copying it.
+        assert config.directory_map["/frontend/"] == ["docs"]
+        assert "frontend/repo_structure.yaml::docs" not in config.structure_rules
+
+    def test_inherit_selected_rules(self, tmp_path):
+        """Test that an explicit list inherits exactly the named rules."""
+        config = _build(
+            tmp_path,
+            {
+                ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                "frontend/repo_structure.yaml": """
+inherit:
+  structure_rules: [docs]
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: docs
+""",
+            },
+        )
+        assert config.directory_map["/frontend/"] == ["docs"]
+
+    def test_inheritance_chains_through_nested_mounts(self, tmp_path):
+        """Test that a rule inherited by a parent stays inheritable further down."""
+        config = _build(
+            tmp_path,
+            {
+                ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                "frontend/repo_structure.yaml": """
+inherit:
+  structure_rules: all
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: docs
+  /ui/:
+    - description: 'Design system'
+    - use_config: repo_structure.yaml
+""",
+                "frontend/ui/repo_structure.yaml": """
+inherit:
+  structure_rules: [docs]
+directory_map:
+  /:
+    - description: 'UI root'
+    - use_rule: docs
+""",
+            },
+        )
+        assert config.directory_map["/frontend/ui/"] == ["docs"]
+
+    def test_override_redefines_only_for_the_child(self, tmp_path):
+        """Test that an overridden rule replaces the inherited one in the child."""
+        config = _build(
+            tmp_path,
+            {
+                ROOT_CONFIG: """
+structure_rules:
+  docs:
+    - description: 'Parent documentation rule'
+    - allow: '.*\\.md'
+directory_map:
+  /:
+    - description: 'Root'
+    - use_rule: docs
+  /frontend/:
+    - description: 'Frontend'
+    - use_config: repo_structure.yaml
+""",
+                "frontend/repo_structure.yaml": """
+inherit:
+  structure_rules: all
+  override: [docs]
+structure_rules:
+  docs:
+    - description: 'Frontend documentation rule'
+    - require: 'GUIDE\\.md'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: docs
+""",
+            },
+        )
+
+        assert config.directory_map["/"] == ["docs"]
+        assert config.directory_map["/frontend/"] == [
+            "frontend/repo_structure.yaml::docs"
+        ]
+        assert [e.path.pattern for e in config.structure_rules["docs"]] == [r".*\.md"]
+        assert [
+            e.path.pattern
+            for e in config.structure_rules["frontend/repo_structure.yaml::docs"]
+        ] == [r"GUIDE\.md"]
+
+
+class TestCollisions:
+    """Test that ambiguity between configurations is reported as an error."""
+
+    def test_redefining_an_inherited_rule_without_override(self, tmp_path):
+        """Test that shadowing an inherited rule by accident is an error."""
+        with pytest.raises(ConfigurationParseError, match="collide with inherited"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                    "frontend/repo_structure.yaml": """
+inherit:
+  structure_rules: all
+structure_rules:
+  docs:
+    - description: 'Frontend documentation rule'
+    - require: 'GUIDE\\.md'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: docs
+""",
+                },
+            )
+
+    def test_override_of_a_rule_that_is_not_inherited(self, tmp_path):
+        """Test that overriding something never inherited is an error."""
+        with pytest.raises(ConfigurationParseError, match="not inherited"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                    "frontend/repo_structure.yaml": """
+inherit:
+  structure_rules: [docs]
+  override: [base]
+structure_rules:
+  base:
+    - description: 'Frontend base'
+    - require: 'index\\.ts'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: base
+""",
+                },
+            )
+
+    def test_inheriting_an_unknown_rule(self, tmp_path):
+        """Test that inheriting a rule the parent does not define is an error."""
+        with pytest.raises(ConfigurationParseError, match="does not define"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                    "frontend/repo_structure.yaml": """
+inherit:
+  structure_rules: [nonexistent]
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: nonexistent
+""",
+                },
+            )
+
+    def test_two_configurations_claiming_one_directory(self, tmp_path):
+        """Test that two configurations mapping the same directory is an error."""
+        with pytest.raises(ConfigurationParseError, match="claimed by more than one"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: """
+structure_rules:
+  base:
+    - description: 'Root files'
+    - require: 'README\\.md'
+directory_map:
+  /:
+    - description: 'Root'
+    - use_rule: base
+  /frontend/components/:
+    - description: 'Claimed by the root configuration too'
+    - use_rule: base
+  /frontend/:
+    - description: 'Frontend'
+    - use_config: repo_structure.yaml
+""",
+                    "frontend/repo_structure.yaml": """
+structure_rules:
+  components:
+    - description: 'Components'
+    - require: 'button\\.ts'
+directory_map:
+  /components/:
+    - description: 'Components'
+    - use_rule: components
+""",
+                },
+            )
+
+    def test_directory_mapping_that_traverses_upwards(self, tmp_path):
+        """Test that a mounted config cannot climb out of its own subtree."""
+        with pytest.raises(ConfigurationParseError, match="traverse"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                    "frontend/repo_structure.yaml": """
+structure_rules:
+  escape:
+    - description: 'Reaches outside the frontend'
+    - require: 'anything'
+directory_map:
+  /../backend/:
+    - description: 'Not mine to govern'
+    - use_rule: escape
+""",
+                },
+            )
+
+    def test_use_config_path_that_traverses_upwards(self, tmp_path):
+        """Test that use_config must point below the directory it applies to."""
+        with pytest.raises(ConfigurationParseError, match="must be a relative path"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: """
+structure_rules:
+  base:
+    - description: 'Root files'
+    - require: 'README\\.md'
+directory_map:
+  /:
+    - description: 'Root'
+    - use_rule: base
+  /frontend/:
+    - description: 'Frontend'
+    - use_config: ../elsewhere/repo_structure.yaml
+""",
+                },
+            )
+
+    def test_mounting_the_same_configuration_twice(self, tmp_path):
+        """Test that reaching one configuration from two mounts is an error.
+
+        Mount paths may not traverse upwards, so two mounts can only land on
+        the same file through a symlink.
+        """
+        with pytest.raises(ConfigurationParseError, match="mounted more than once"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: """
+structure_rules:
+  base:
+    - description: 'Root files'
+    - require: 'README\\.md'
+directory_map:
+  /:
+    - description: 'Root'
+    - use_rule: base
+  /frontend/:
+    - description: 'Frontend'
+    - use_config: repo_structure.yaml
+  /backend/:
+    - description: 'Backend'
+    - use_config: repo_structure.yaml
+""",
+                    "shared/repo_structure.yaml": """
+structure_rules:
+  package:
+    - description: 'A package'
+    - require: 'main\\.py'
+directory_map:
+  /:
+    - description: 'Team root'
+    - use_rule: package
+""",
+                },
+                """
+shared/
+frontend -> shared
+backend -> shared
+""",
+            )
+
+    def test_mount_cycle(self, tmp_path):
+        """Test that a configuration reachable from itself is an error."""
+        with pytest.raises(ConfigurationParseError, match="mounted more than once"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: """
+structure_rules:
+  base:
+    - description: 'Root files'
+    - require: 'README\\.md'
+directory_map:
+  /:
+    - description: 'Root'
+    - use_rule: base
+  /self/:
+    - description: 'Loops back onto the top-level configuration'
+    - use_config: repo_structure.yaml
+"""
+                },
+                """
+self -> .
+""",
+            )
+
+    def test_directory_both_maps_rules_and_mounts_a_configuration(self, tmp_path):
+        """Test that a directory cannot be governed twice by one configuration."""
+        with pytest.raises(ConfigurationParseError, match="both maps structure rules"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: """
+structure_rules:
+  base:
+    - description: 'Root files'
+    - require: 'README\\.md'
+directory_map:
+  /:
+    - description: 'Root'
+    - use_rule: base
+  /frontend/:
+    - description: 'Frontend'
+    - use_rule: base
+    - use_config: repo_structure.yaml
+""",
+                    "frontend/repo_structure.yaml": """
+structure_rules:
+  ts_package:
+    - description: 'TypeScript package'
+    - require: 'index\\.ts'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: ts_package
+""",
+                },
+            )
+
+    def test_missing_mounted_configuration(self, tmp_path):
+        """Test that mounting a configuration that is not there is an error."""
+        with pytest.raises(ConfigurationParseError, match="does not exist"):
+            _build(tmp_path, {ROOT_CONFIG: _PARENT_WITH_FRONTEND})
+
+    def test_inherit_in_a_top_level_configuration(self, tmp_path):
+        """Test that inheriting without a parent to inherit from is an error."""
+        with pytest.raises(ConfigurationParseError, match="no parent to inherit from"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: """
+inherit:
+  structure_rules: all
+structure_rules:
+  base:
+    - description: 'Root files'
+    - require: 'README\\.md'
+directory_map:
+  /:
+    - description: 'Root'
+    - use_rule: base
+"""
+                },
+            )
+
+    def test_override_without_inheriting(self, tmp_path):
+        """Test that an override list without inheritance is an error."""
+        with pytest.raises(ConfigurationParseError, match="requires 'inherit"):
+            _build(
+                tmp_path,
+                {
+                    ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                    "frontend/repo_structure.yaml": """
+inherit:
+  override: [docs]
+structure_rules:
+  docs:
+    - description: 'Frontend documentation rule'
+    - require: 'GUIDE\\.md'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: docs
+""",
+                },
+            )
+
+    def test_use_config_is_rejected_for_yaml_strings(self):
+        """Test that use_config needs a file, since its path is config relative."""
+        with pytest.raises(
+            ConfigurationParseError, match="only supported when loading"
+        ):
+            Configuration.from_yaml_string(_PARENT_WITH_FRONTEND)
+
+
+class TestScanningWithMountedConfigurations:
+    """Test that scans honour every configuration taking part in the load."""
+
+    def _scan(self, tmp_path, configs, tree):
+        repo = create_repo_structure(tmp_path, tree)
+        config = Configuration.from_file(_write_configs(repo, configs))
+        return FullScanProcessor(repo, config, Flags()).scan()
+
+    def test_mounted_configuration_governs_its_subtree(self, tmp_path):
+        """Test that a violation below a mount point is found and located."""
+        result = self._scan(
+            tmp_path,
+            {
+                ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                "frontend/repo_structure.yaml": """
+structure_rules:
+  ts_package:
+    - description: 'TypeScript package'
+    - require: 'index\\.ts'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: ts_package
+""",
+            },
+            """
+README.md
+frontend/
+frontend/index.ts
+frontend/stray.txt
+""",
+        )
+
+        assert [(e.code, e.path) for e in result.errors] == [
+            ("unspecified_entry", "frontend/stray.txt")
+        ]
+
+    def test_mounted_configuration_files_are_not_reported(self, tmp_path):
+        """Test that the configuration files themselves are skipped."""
+        result = self._scan(
+            tmp_path,
+            {
+                ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                "frontend/repo_structure.yaml": """
+structure_rules:
+  ts_package:
+    - description: 'TypeScript package'
+    - require: 'index\\.ts'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: ts_package
+""",
+            },
+            """
+README.md
+frontend/
+frontend/index.ts
+""",
+        )
+
+        assert result.is_success
+
+    def test_unused_mounted_rule_names_its_configuration(self, tmp_path):
+        """Test that an unused rule is reported with the file that defines it."""
+        result = self._scan(
+            tmp_path,
+            {
+                ROOT_CONFIG: _PARENT_WITH_FRONTEND,
+                "frontend/repo_structure.yaml": """
+structure_rules:
+  ts_package:
+    - description: 'TypeScript package'
+    - require: 'index\\.ts'
+  unused:
+    - description: 'Never mapped anywhere'
+    - require: 'nothing'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: ts_package
+""",
+            },
+            """
+README.md
+frontend/
+frontend/index.ts
+""",
+        )
+
+        messages = [w.message for w in result.warnings]
+        assert messages == [
+            "Unused structure rule 'docs'",
+            "Unused structure rule 'unused' in 'frontend/repo_structure.yaml'",
+        ]

--- a/repo_structure/config_test.py
+++ b/repo_structure/config_test.py
@@ -505,6 +505,62 @@ directory_map:
         Configuration(test_config, True)
 
 
+def test_fail_qualifier_in_structure_rule_name():
+    """Test that '::' is reserved for qualified rule names."""
+    test_config = """
+structure_rules:
+    team::rule:
+        - description: 'Uses the reserved namespace separator'
+        - require: 'some_file.md'
+directory_map:
+    /:
+        - description: 'Root directory'
+        - use_rule: team::rule
+    """
+    with pytest.raises(ConfigurationParseError):
+        Configuration.from_yaml_string(test_config)
+
+
+def test_fail_use_config_combined_with_use_rule():
+    """Test that one directory map entry cannot both map and mount."""
+    test_config = """
+structure_rules:
+    correct_rule:
+        - description: 'Correct rule'
+        - require: 'some_file.md'
+directory_map:
+    /:
+        - description: 'Root directory'
+        - use_rule: correct_rule
+    /frontend/:
+        - description: 'Frontend directory'
+        - use_rule: correct_rule
+          use_config: repo_structure.yaml
+    """
+    with pytest.raises(ConfigurationParseError):
+        Configuration.from_yaml_string(test_config)
+
+
+def test_fail_two_configs_mounted_at_one_directory():
+    """Test that a directory cannot mount two configurations."""
+    test_config = """
+structure_rules:
+    correct_rule:
+        - description: 'Correct rule'
+        - require: 'some_file.md'
+directory_map:
+    /:
+        - description: 'Root directory'
+        - use_rule: correct_rule
+    /frontend/:
+        - description: 'Frontend directory'
+        - use_config: repo_structure.yaml
+        - use_config: other.yaml
+    """
+    with pytest.raises(ConfigurationParseError, match="more than one configuration"):
+        Configuration.from_yaml_string(test_config)
+
+
 def test_fail_double_underscore_prefix_template():
     """Test failing template with parameters and only have a use_rule."""
     test_config = """

--- a/repo_structure/diff_scan.py
+++ b/repo_structure/diff_scan.py
@@ -62,6 +62,7 @@ class DiffScanProcessor:
         self.config = config
         self.flags = flags if flags is not None else Flags()
         self.repo_root = repo_root
+        self.config_file_names = config.configuration_file_names_for(repo_root)
 
     def _incremental_path_split(
         self, path_to_split: str
@@ -109,7 +110,7 @@ class DiffScanProcessor:
                     path=entry_name, rel_dir=rel_dir, is_dir=is_dir, is_symlink=False
                 ),
                 self.config.directory_map,
-                self.config.configuration_file_name,
+                self.config_file_names,
                 flags=self.flags,
             ):
                 return None

--- a/repo_structure/full_scan.py
+++ b/repo_structure/full_scan.py
@@ -10,6 +10,7 @@ from gitignore_parser import parse_gitignore
 from .config import (
     Configuration,
 )
+from .config_merge import unqualify
 
 from .models import (
     BUILTIN_DIRECTORY_RULES,
@@ -54,6 +55,7 @@ class FullScanProcessor:
         self.config = config
         self.flags = flags if flags is not None else Flags()
         self.git_ignore = self._get_git_ignore()
+        self.config_file_names = config.configuration_file_names_for(repo_root)
 
     def _get_git_ignore(self) -> Callable[[str], bool] | None:
         """Get gitignore parser, cached for the lifetime of the scan.
@@ -160,7 +162,7 @@ class FullScanProcessor:
         return skip_entry(
             entry,
             self.config.directory_map,
-            self.config.configuration_file_name,
+            self.config_file_names,
             self.git_ignore,
             self.flags,
         )
@@ -279,11 +281,23 @@ class FullScanProcessor:
                     ScanIssue(
                         severity="warning",
                         code="unused_structure_rule",
-                        message=f"Unused structure rule '{rule_name}'",
+                        message=self._unused_rule_message(rule_name),
                         path=None,
                     )
                 )
         return warnings
+
+    def _unused_rule_message(self, rule_name: str) -> str:
+        """Name an unused rule the way its own configuration file spells it.
+
+        A rule from a mounted configuration is reported with that file's path,
+        so the warning says whose configuration it is about.
+        """
+        message = f"Unused structure rule '{unqualify(rule_name)}'"
+        origin = self.config.rule_origins.get(rule_name, "")
+        if origin and origin != self.config.configuration_file_name:
+            message += f" in '{origin}'"
+        return message
 
     def scan(self) -> ScanResult:
         """Scan the repository and return the errors and warnings found."""

--- a/repo_structure/models.py
+++ b/repo_structure/models.py
@@ -46,6 +46,71 @@ DirectoryMap = dict[str, list[str]]
 StructureRuleList = list[RepoEntry]
 StructureRuleMap = dict[str, StructureRuleList]
 
+INHERIT_ALL: Final = "all"
+
+
+@dataclass
+class InheritSpec:
+    """What a configuration takes over from the configuration that mounted it.
+
+    ``structure_rules`` is either :data:`INHERIT_ALL`, an explicit list of rule
+    names, or None when the configuration inherits nothing. ``override`` names
+    the inherited rules the configuration deliberately redefines; redefining an
+    inherited rule that is not listed here is an error.
+    """
+
+    structure_rules: str | list[str] | None = None
+    override: list[str] = field(default_factory=list)
+
+    @property
+    def inherits_everything(self) -> bool:
+        """True if the configuration asked for every parent structure rule."""
+        return self.structure_rules == INHERIT_ALL
+
+
+@dataclass
+class ParsedDocument:
+    """One configuration document, parsed but not yet merged with others.
+
+    Rule names are still exactly as written in the document -- qualification
+    into the merged namespace happens during the merge, not here. Likewise,
+    ``directory_map`` keys are relative to the document's own directory.
+    """
+
+    structure_rules: StructureRuleMap = field(default_factory=dict)
+    structure_rule_descriptions: dict[str, str] = field(default_factory=dict)
+    directory_map: DirectoryMap = field(default_factory=dict)
+    directory_descriptions: dict[str, str] = field(default_factory=dict)
+    mounts: dict[str, str] = field(default_factory=dict)
+    inherit: InheritSpec = field(default_factory=InheritSpec)
+
+
+@dataclass
+class ConfigurationData:
+    """Stores configuration data.
+
+    This is the flattened result of merging every configuration document that
+    took part in a load. Rules contributed by a mounted configuration are keyed
+    by their qualified name (see ``config_merge.qualify``); ``rule_origins``
+    maps each rule back to the configuration file that defined it.
+    """
+
+    structure_rules: StructureRuleMap = field(default_factory=dict)
+    directory_map: DirectoryMap = field(default_factory=dict)
+    configuration_file_name: str = ""
+    structure_rule_descriptions: dict[str, str] = field(default_factory=dict)
+    directory_descriptions: dict[str, str] = field(default_factory=dict)
+    configuration_file_names: set[str] = field(default_factory=set)
+    rule_origins: dict[str, str] = field(default_factory=dict)
+
+    def get_structure_rule_description(self, rule_name: str) -> str:
+        """Get the description for a structure rule."""
+        return self.structure_rule_descriptions.get(rule_name, "")
+
+    def get_directory_description(self, directory: str) -> str:
+        """Get the description for a directory."""
+        return self.directory_descriptions.get(directory, "")
+
 
 @dataclass
 class ScanIssue:

--- a/repo_structure/paths.py
+++ b/repo_structure/paths.py
@@ -24,6 +24,20 @@ def join_path_normalized(*parts: str) -> str:
     return normalize_path(str(joined))
 
 
+def relative_to_root(path: str, repo_root: str) -> str | None:
+    """Express `path` relative to `repo_root`, or None if it lies outside.
+
+    Used to recognise the configuration file itself while scanning: it may be
+    passed on the command line as any path, while scanning compares against
+    paths relative to the repository root.
+    """
+    try:
+        relative = Path(path).resolve().relative_to(Path(repo_root).resolve())
+    except ValueError:
+        return None
+    return normalize_path(str(relative))
+
+
 def rel_dir_to_map_dir(rel_dir: str):
     """Convert a relative directory path to a mapped directory path.
 

--- a/repo_structure/repo_structure.yaml
+++ b/repo_structure/repo_structure.yaml
@@ -1,0 +1,25 @@
+# Configuration for the repo_structure package directory, mounted by the
+# repository root configuration through 'use_config'. Paths here are relative
+# to this directory: '/' below means '/repo_structure/'.
+structure_rules:
+  python_package:
+    - description: "Standard Python package structure with modules, tests, and configuration files"
+    - require: '__main__\.py'
+    - require: '__init__\.py'
+    # Specify files that don't need a companion first
+    - allow: '_version\.py'
+    # TODO: Add test for the schema
+    - allow: 'schema\.py'
+    - allow: 'test_lib\.py'
+    - allow: '.*_test\.py'
+    # Specify the companion
+    - allow: '(?P<base>.*)\.py'
+      companion:
+        - require: '{{base}}_test\.py'
+    - require: 'config\.schema\.json'
+    - require: 'test_config_.*\.yaml'
+
+directory_map:
+  /:
+    - description: "Python package modules, each with its companion test beside it"
+    - use_rule: python_package

--- a/repo_structure/report.py
+++ b/repo_structure/report.py
@@ -1,11 +1,13 @@
 """Report generation functionality for repo structure configuration."""
 
 import json
+import re
 import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Callable, Literal
 from .config import Configuration
+from .config_merge import unqualify
 from .models import (
     BUILTIN_DIRECTORY_RULES,
     DirectoryMap,
@@ -39,7 +41,14 @@ class DirectoryReport:
 
 @dataclass
 class StructureRuleReport:
-    """Report data for a single structure rule."""
+    """Report data for a single structure rule.
+
+    ``rule_name`` is the name the rule has in the merged configuration, which
+    for a rule owned by a mounted configuration is qualified with that
+    configuration's path -- ``unqualify`` recovers the name as written in the
+    file that defines it. ``source_config`` names that file, and is empty when
+    the rule comes from the top-level configuration.
+    """
 
     rule_name: str
     description: str
@@ -47,6 +56,7 @@ class StructureRuleReport:
     directory_descriptions: list[str]
     rule_count: int
     patterns: list[str]
+    source_config: str = ""
 
 
 @dataclass
@@ -124,6 +134,8 @@ def generate_report(config: Configuration, repo_root: str = ".") -> Configuratio
     Returns:
         A complete configuration report with directory and structure rule information.
     """
+    sources = _rule_sources(config)
+
     directory_reports = _generate_directory_reports(
         config.directory_map,
         config.directory_descriptions,
@@ -135,6 +147,7 @@ def generate_report(config: Configuration, repo_root: str = ".") -> Configuratio
         config.directory_map,
         config.structure_rule_descriptions,
         config.directory_descriptions,
+        sources,
     )
 
     repository_info = get_repository_info(repo_root)
@@ -146,6 +159,29 @@ def generate_report(config: Configuration, repo_root: str = ".") -> Configuratio
         total_structure_rules=len(structure_rule_reports),
         repository_info=repository_info,
     )
+
+
+def _rule_sources(config: Configuration) -> dict[str, str]:
+    """Map each rule to the mounted configuration that defines it.
+
+    Rules of the top-level configuration map to the empty string: naming the
+    file they came from would be noise in a single-file repository.
+    """
+    top_level = config.configuration_file_name
+    return {
+        rule_name: "" if origin == top_level else origin
+        for rule_name, origin in config.rule_origins.items()
+    }
+
+
+def _rule_anchor(rule_name: str) -> str:
+    """Build a markdown anchor id for a rule section.
+
+    Qualified rule names carry a configuration path, so anything that is not
+    safe in an anchor collapses to a dash. Plain rule names come through
+    unchanged.
+    """
+    return "rule-" + re.sub(r"[^A-Za-z0-9_-]+", "-", rule_name)
 
 
 def _generate_directory_reports(
@@ -187,6 +223,7 @@ def _generate_structure_rule_reports(
     directory_map: DirectoryMap,
     structure_rule_descriptions: dict[str, str],
     directory_descriptions: dict[str, str],
+    rule_sources: dict[str, str],
 ) -> list[StructureRuleReport]:
     """Generate reports for each structure rule."""
 
@@ -274,6 +311,7 @@ def _generate_structure_rule_reports(
                 directory_descriptions=directory_descs,
                 rule_count=len(rule_entries),
                 patterns=patterns,
+                source_config=rule_sources.get(rule_name, ""),
             )
         )
 
@@ -335,10 +373,11 @@ def _format_directory_mappings_text(
     lines.append("-" * 20)
     for dir_report in directory_reports:
         display_dir = _normalize_directory_display(dir_report.directory)
+        rule_names = [unqualify(rule) for rule in dir_report.applied_rules]
         lines.append(f"Directory: {display_dir}")
         lines.append(f"  Description: {dir_report.description}")
-        lines.append(f"  Applied Rules: {', '.join(dir_report.applied_rules)}")
-        for rule, desc in zip(dir_report.applied_rules, dir_report.rule_descriptions):
+        lines.append(f"  Applied Rules: {', '.join(rule_names)}")
+        for rule, desc in zip(rule_names, dir_report.rule_descriptions):
             lines.append(f"    - {rule}: {desc}")
         lines.append("")
     return lines
@@ -359,7 +398,9 @@ def _format_structure_rules_text(
     lines.append("Structure Rules")
     lines.append("-" * 15)
     for rule_report in structure_rule_reports:
-        lines.append(f"Rule: {rule_report.rule_name}")
+        lines.append(f"Rule: {unqualify(rule_report.rule_name)}")
+        if rule_report.source_config:
+            lines.append(f"  Defined in: {rule_report.source_config}")
         lines.append(f"  Description: {rule_report.description}")
 
         # Only show entry count and patterns if there are any
@@ -498,7 +539,7 @@ def format_report_markdown(report: ConfigurationReport) -> str:
         lines.append("**Applied Rules:**")
         for rule, desc in zip(dir_report.applied_rules, dir_report.rule_descriptions):
             # Link to the rule section
-            lines.append(f"- [`{rule}`](#rule-{rule}): {desc}")
+            lines.append(f"- [`{unqualify(rule)}`](#{_rule_anchor(rule)}): {desc}")
         lines.append("")
 
     # Structure rule dimension
@@ -506,10 +547,14 @@ def format_report_markdown(report: ConfigurationReport) -> str:
     lines.append("")
     for rule_report in report.structure_rule_reports:
         # Create anchor for this rule
+        display_name = unqualify(rule_report.rule_name)
         lines.append(
-            f"### Rule: `{rule_report.rule_name}` {{#rule-{rule_report.rule_name}}}"
+            f"### Rule: `{display_name}` {{#{_rule_anchor(rule_report.rule_name)}}}"
         )
         lines.append("")
+        if rule_report.source_config:
+            lines.append(f"**Defined in:** `{rule_report.source_config}`")
+            lines.append("")
         lines.append(f"**Description:** {rule_report.description}")
 
         # Only show entry count and patterns if there are any

--- a/repo_structure/report_test.py
+++ b/repo_structure/report_test.py
@@ -623,3 +623,56 @@ directory_map:
     # Verify in JSON output
     json_output = format_report_json(report)
     assert "companion" in json_output
+
+
+def test_report_names_the_configuration_that_defines_a_rule(tmp_path):
+    """Test that rules from a mounted configuration are attributed to it."""
+    (tmp_path / "frontend").mkdir()
+    (tmp_path / "repo_structure.yaml").write_text(
+        """
+structure_rules:
+  base:
+    - description: 'Root files'
+    - require: 'README\\.md'
+directory_map:
+  /:
+    - description: 'Root directory'
+    - use_rule: base
+  /frontend/:
+    - description: 'Owned by the frontend team'
+    - use_config: repo_structure.yaml
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "frontend" / "repo_structure.yaml").write_text(
+        """
+structure_rules:
+  base:
+    - description: 'Frontend files'
+    - require: 'index\\.ts'
+directory_map:
+  /:
+    - description: 'Frontend root'
+    - use_rule: base
+""",
+        encoding="utf-8",
+    )
+
+    config = Configuration.from_file(str(tmp_path / "repo_structure.yaml"))
+    report = generate_report(config, str(tmp_path))
+
+    by_name = {r.rule_name: r for r in report.structure_rule_reports}
+    assert by_name["base"].source_config == ""
+
+    mounted = by_name["frontend/repo_structure.yaml::base"]
+    assert mounted.source_config == "frontend/repo_structure.yaml"
+
+    # Both rules are called 'base', so the report has to say which is which.
+    text_output = format_report_text(report)
+    assert "Defined in: frontend/repo_structure.yaml" in text_output
+
+    # Anchors stay unique and link-safe despite the shared display name.
+    markdown_output = format_report_markdown(report)
+    assert "{#rule-base}" in markdown_output
+    assert "{#rule-frontend-repo_structure-yaml-base}" in markdown_output
+    assert "[`base`](#rule-frontend-repo_structure-yaml-base)" in markdown_output

--- a/repo_structure/scanning.py
+++ b/repo_structure/scanning.py
@@ -37,7 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 def skip_entry(
     entry: Entry,
     directory_map: DirectoryMap,
-    config_file_name: str,
+    config_file_names: set[str],
     git_ignore: Callable[[str], bool] | None = None,
     flags: Flags | None = None,
 ) -> bool:
@@ -45,21 +45,24 @@ def skip_entry(
 
     `git_ignore` is called with the entry's path relative to the repository
     root, so it must resolve that against the root rather than the process CWD.
+
+    `config_file_names` holds every configuration file taking part in the scan.
+    A configuration mounted through `use_config` lives in the subdirectory it
+    governs, so entries are matched on their repository-root relative path as
+    well as on their bare name.
     """
     if flags is None:
         flags = Flags()
+    rel_path = join_path_normalized(entry.rel_dir, entry.path)
     skip_conditions = [
         (not flags.follow_symlinks and entry.is_symlink),
         (not flags.include_hidden and entry.path.startswith(".")),
         (entry.path == ".gitignore" and not entry.is_dir),
         (entry.path == ".git" and entry.is_dir),
-        (git_ignore and git_ignore(join_path_normalized(entry.rel_dir, entry.path))),
-        (
-            entry.is_dir
-            and rel_dir_to_map_dir(join_path_normalized(entry.rel_dir, entry.path))
-            in directory_map
-        ),
-        (entry.path == config_file_name),
+        (git_ignore and git_ignore(rel_path)),
+        (entry.is_dir and rel_dir_to_map_dir(rel_path) in directory_map),
+        (entry.path in config_file_names),
+        (rel_path in config_file_names),
     ]
 
     for condition in skip_conditions:

--- a/repo_structure/scanning_test.py
+++ b/repo_structure/scanning_test.py
@@ -26,43 +26,43 @@ class TestSkipEntry:
         """Test that symlinks are skipped when follow_symlinks is False."""
         entry = Entry(path="link", rel_dir="", is_dir=False, is_symlink=True)
         flags = Flags(follow_symlinks=False)
-        assert skip_entry(entry, {}, "config.yaml", None, flags) is True
+        assert skip_entry(entry, {}, {"config.yaml"}, None, flags) is True
 
     def test_skip_entry_symlink_follow(self):
         """Test that symlinks are not skipped when follow_symlinks is True."""
         entry = Entry(path="link", rel_dir="", is_dir=False, is_symlink=False)
         flags = Flags(follow_symlinks=True)
-        assert skip_entry(entry, {}, "config.yaml", None, flags) is False
+        assert skip_entry(entry, {}, {"config.yaml"}, None, flags) is False
 
     def test_skip_entry_hidden_no_include(self):
         """Test that hidden files are skipped when include_hidden is False."""
         entry = Entry(path=".hidden", rel_dir="", is_dir=False, is_symlink=False)
         flags = Flags(include_hidden=False)
-        assert skip_entry(entry, {}, "config.yaml", None, flags) is True
+        assert skip_entry(entry, {}, {"config.yaml"}, None, flags) is True
 
     def test_skip_entry_hidden_include(self):
         """Test that hidden files are not skipped when include_hidden is True."""
         entry = Entry(path=".hidden", rel_dir="", is_dir=False, is_symlink=False)
         flags = Flags(include_hidden=True)
-        assert skip_entry(entry, {}, "config.yaml", None, flags) is False
+        assert skip_entry(entry, {}, {"config.yaml"}, None, flags) is False
 
     def test_skip_entry_gitignore_file(self):
         """Test that .gitignore file is skipped."""
         entry = Entry(path=".gitignore", rel_dir="", is_dir=False, is_symlink=False)
         flags = Flags()
-        assert skip_entry(entry, {}, "config.yaml", None, flags) is True
+        assert skip_entry(entry, {}, {"config.yaml"}, None, flags) is True
 
     def test_skip_entry_git_dir(self):
         """Test that .git directory is skipped."""
         entry = Entry(path=".git", rel_dir="", is_dir=True, is_symlink=False)
         flags = Flags()
-        assert skip_entry(entry, {}, "config.yaml", None, flags) is True
+        assert skip_entry(entry, {}, {"config.yaml"}, None, flags) is True
 
     def test_skip_entry_config_file(self):
         """Test that config file is skipped."""
         entry = Entry(path="config.yaml", rel_dir="", is_dir=False, is_symlink=False)
         flags = Flags()
-        assert skip_entry(entry, {}, "config.yaml", None, flags) is True
+        assert skip_entry(entry, {}, {"config.yaml"}, None, flags) is True
 
     def test_skip_entry_git_ignore_function(self):
         """Test that entries matching gitignore are skipped."""
@@ -72,20 +72,42 @@ class TestSkipEntry:
             return path == "ignored.txt"
 
         flags = Flags()
-        assert skip_entry(entry, {}, "config.yaml", git_ignore, flags) is True
+        assert skip_entry(entry, {}, {"config.yaml"}, git_ignore, flags) is True
 
     def test_skip_entry_directory_in_map(self):
         """Test that directories in directory_map are skipped."""
         entry = Entry(path="subdir", rel_dir="app", is_dir=True, is_symlink=False)
         directory_map = {"/app/subdir/": ["rule1"]}
         flags = Flags()
-        assert skip_entry(entry, directory_map, "config.yaml", None, flags) is True
+        assert skip_entry(entry, directory_map, {"config.yaml"}, None, flags) is True
 
     def test_skip_entry_normal_file(self):
         """Test that normal files are not skipped."""
         entry = Entry(path="file.txt", rel_dir="", is_dir=False, is_symlink=False)
         flags = Flags()
-        assert skip_entry(entry, {}, "config.yaml", None, flags) is False
+        assert skip_entry(entry, {}, {"config.yaml"}, None, flags) is False
+
+    def test_skip_entry_mounted_config_file(self):
+        """Test that a config file mounted in a subdirectory is skipped."""
+        entry = Entry(
+            path="repo_structure.yaml",
+            rel_dir="frontend",
+            is_dir=False,
+            is_symlink=False,
+        )
+        config_files = {"repo_structure.yaml", "frontend/repo_structure.yaml"}
+        assert skip_entry(entry, {}, config_files, None, Flags()) is True
+
+    def test_skip_entry_config_file_name_in_other_directory(self):
+        """Test that a mounted config is only skipped in the directory it sits in."""
+        entry = Entry(
+            path="repo_structure.yaml",
+            rel_dir="backend",
+            is_dir=False,
+            is_symlink=False,
+        )
+        config_files = {"frontend/repo_structure.yaml"}
+        assert skip_entry(entry, {}, config_files, None, Flags()) is False
 
 
 class TestToEntry:


### PR DESCRIPTION
Closes #216.

Lets a repository split its configuration across directories, so the team that
owns a directory owns the rules for it.

## How it works

A `directory_map` entry hands a directory over to another configuration file:

```yaml
# repo_structure.yaml, at the repository root
directory_map:
  /:
    - description: "Root directory"
    - use_rule: base
  /frontend/:
    - description: "Owned by the frontend team"
    - use_config: repo_structure.yaml   # reads frontend/repo_structure.yaml
```

Inside the mounted file, `/` is the directory it was mounted at, so the frontend
team writes their config as though their directory were the repository. Mounted
configurations can mount further configurations of their own.

Rules are private to the file that defines them. A configuration that wants its
parent's rules says so explicitly:

```yaml
# frontend/repo_structure.yaml
inherit:
  structure_rules: all      # or an explicit list: [docs, base]
  override: [docs]          # deliberate redefinition, otherwise an error
```

## Design

Two ideas carry the merge, both in the new `config_merge.py`:

**Qualification.** Rules from a mounted configuration are stored as
`<config path>::<rule name>`, so two teams may both define `python_package`
without colliding. Rules of the top-level configuration keep their bare names —
which is what makes a single-file configuration merge to *exactly* what it
parsed to today. That is the main backwards-compatibility guarantee here, and
the existing 254 tests cover it.

**Inheritance is aliasing, not copying.** `inherit.structure_rules` makes the
parent's qualified name reachable under its bare name in the child; it registers
no new rule. Two consequences worth knowing: changing a rule in the parent
propagates to everyone inheriting it, and an inherited-but-unused rule produces
no spurious `unused_structure_rule` warning.

## Collisions are errors

Per the issue's preference for errors over warnings, anything ambiguous about
which definition wins fails the load:

| Situation | Why |
| --- | --- |
| A rule redefines an inherited name without `inherit.override` | Unclear whether shadowing was intended |
| `inherit.override` names a rule that is not inherited | Nothing to override |
| `inherit.structure_rules` names a rule the parent does not define | Cannot be resolved |
| Two configurations map the same directory | Two owners for one directory |
| A `directory_map` key or `use_config` path traverses upwards with `..` | A config would govern a subtree it was not given |
| The same configuration file is reached from two mounts | One file would describe two directories |
| One entry combines `use_config` with `use_rule`/`use_template` | The directory would be governed twice |
| A top-level configuration declares `inherit` | No parent to inherit from |

## Supporting changes

- **`config.py`** splits into a single-document parser (`load_document` /
  `parse_document`) and a thin `Configuration` facade. `config_merge` receives
  the parser as a callable, which keeps the module dependencies a DAG rather
  than a cycle — worth a look, it is the one non-obvious structural choice.
- **`skip_entry`** now takes the set of participating configuration files and
  matches repository-root relative paths, so a config mounted in a subdirectory
  is not reported as an unspecified entry. It previously compared the config
  path against a bare *filename*, which only ever worked for a root-level
  `repo_structure.yaml`.
- **Reports** name the file each rule comes from (`Defined in: ...`), which is
  what tells two same-named rules apart; markdown anchors are sanitised so
  qualified names stay unique and link-safe.

## Review notes

Things I would look at hardest:

1. The callable-injection seam between `config.py` and `config_merge.py`.
2. Whether "child's `/` description wins over the parent's mount description"
   is the right call (`_register_directory_map`).
3. `unqualify` splits on the *last* `::`; the schema now forbids `::` in rule
   names to make that unambiguous.

## Verification

- `uv run --extra dev pytest` — 292 pass (36 new)
- `uv run prek run --all-files` — clean
- `uv run repo_structure full-scan` — this repo still validates
- Manual: a three-config scratch repo exercising full-scan, diff-scan, override,
  and each collision error

## Not included

- Templates are not inheritable (agreed scope decision) — `inherit` covers
  `structure_rules` only.
- No auto-discovery of `repo_structure.yaml` files; mounting is always explicit.

## This repo now dogfoods the feature

The second commit splits this repository's own configuration in two: the
`python_package` rule (including the `companion` rule that is the tool's
flagship feature) moves into `repo_structure/repo_structure.yaml`, and the root
config delegates `/repo_structure/` to it with `use_config`.

One trap worth knowing, since CLAUDE.md warns about it: hatchling's wheel
`exclude` matches file patterns, so the new config would have shipped to PyPI as
if it were runtime data. It is now in the exclude list. Verified against a built
wheel (contains neither `repo_structure.yaml` nor any test file) and sdist
(keeps both).

An earlier version of this description claimed dogfooding was not possible
because `python_package` has no generic `*.yaml` allow. That was wrong: mounted
configuration files are skipped by the scan, which is exactly what this PR
added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
