### PR TITLE
Tier 2 cleanup: fix shared scan counters, memoize companion lookups

### DIFF
--- a/repo_structure/benchmark_test.py
+++ b/repo_structure/benchmark_test.py
@@ -4,7 +4,7 @@ import os
 from typing import Final
 import pytest
 
-from .test_lib import create_random_repo_structure
+from .test_lib import create_random_repo_structure, create_repo_structure
 from .full_scan import FullScanProcessor
 from .config import Configuration
 
@@ -22,6 +22,22 @@ directory_map:
     - use_rule: allow_all
 """
 
+COMPANION_CONFIG: Final = r"""
+structure_rules:
+  sources_with_tests:
+    - description: 'Every module needs a test beside it'
+    - allow: '(?P<base>.*)_test\.py'
+    - allow: '(?P<base>.*)\.py'
+      companion:
+        - require: '{{base}}_test\.py'
+directory_map:
+  /:
+    - description: 'Root directory'
+    - use_rule: sources_with_tests
+"""
+
+_COMPANION_MODULE_COUNT: Final = 150
+
 
 @pytest.mark.skipif(
     os.environ.get("GITHUB_RUN_ID", "") != "", reason="Only run on local machine."
@@ -32,3 +48,23 @@ def test_benchmark_repo_structure_default(benchmark, tmp_path):
     config = Configuration.from_yaml_string(ALLOW_ALL_CONFIG)
     processor = FullScanProcessor(repo, config)
     benchmark(processor.scan)
+
+
+@pytest.mark.skipif(
+    os.environ.get("GITHUB_RUN_ID", "") != "", reason="Only run on local machine."
+)
+def test_benchmark_companion_heavy_directory(benchmark, tmp_path):
+    """Benchmark a directory where every file triggers a companion lookup.
+
+    Each companion is searched for below the matched file's directory, so this
+    is the case that used to walk the same subtree once per module.
+    """
+    specification = "\n".join(
+        f"module_{i}.py\nmodule_{i}_test.py" for i in range(_COMPANION_MODULE_COUNT)
+    )
+    repo = create_repo_structure(tmp_path, specification)
+    config = Configuration.from_yaml_string(COMPANION_CONFIG)
+    processor = FullScanProcessor(repo, config)
+
+    result = benchmark(processor.scan)
+    assert result.is_success

--- a/repo_structure/config.py
+++ b/repo_structure/config.py
@@ -227,9 +227,7 @@ def parse_document(
         mounts=mounts,
         inherit=_parse_inherit(yaml_dict.get("inherit", {})),
     )
-    _parse_templates_to_document(
-        yaml_dict.get("templates", {}), directory_map_yaml, document
-    )
+    _add_template_rules(yaml_dict.get("templates", {}), directory_map_yaml, document)
     return document
 
 
@@ -306,75 +304,69 @@ def _load_repo_structure_yamls(yaml_string: str | TextIO) -> dict:
     return yaml.load(yaml_string)
 
 
+def _is_description(entry: dict) -> bool:
+    """True if a YAML entry is the description object and nothing else."""
+    return "description" in entry and len(entry) == 1
+
+
+def _take_description(entries: list[dict], context: str) -> tuple[str, list[dict]]:
+    """Split a section into its leading description and the entries that follow.
+
+    Both structure rules and directory maps are written as a list whose first
+    element carries the description, so both are read the same way here.
+
+    Args:
+        entries: The raw YAML list.
+        context: What is being parsed, for the error messages.
+    """
+    if not entries:
+        raise ConfigurationParseError(f"{context} cannot be empty")
+
+    if not _is_description(entries[0]):
+        raise ConfigurationParseError(
+            f"First entry in {context.lower()} must be a description object "
+            "with only 'description' field"
+        )
+
+    return entries[0]["description"], entries[1:]
+
+
 def _parse_structure_rules(
     structure_rules_yaml: dict,
 ) -> tuple[StructureRuleMap, dict[str, str]]:
-
-    def _validate_use_rule_not_dangling(rules: StructureRuleMap) -> None:
-        for rule_key in rules.keys():
-            for entry in rules[rule_key]:
-                if entry.use_rule and entry.use_rule not in rules:
-                    raise ConfigurationParseError(
-                        f"use_rule '{entry.use_rule}' in entry '{entry.path.pattern}'"
-                        "is not a valid rule key"
-                    )
-
-    def _validate_use_rule_only_recursive(rules: StructureRuleMap) -> None:
-        for rule_key in rules.keys():
-            for entry in rules[rule_key]:
-                if entry.use_rule and entry.use_rule != rule_key:
-                    raise ConfigurationParseError(
-                        f"use_rule '{entry.use_rule}' in entry '{entry.path.pattern}'"
-                        "is not recursive"
-                    )
-
-    rules, descriptions = _build_rules(structure_rules_yaml)
-    _validate_use_rule_not_dangling(rules)
-    _validate_use_rule_only_recursive(rules)
-
-    return rules, descriptions
-
-
-def _build_rules(
-    structure_rules_yaml: dict,
-) -> tuple[StructureRuleMap, dict[str, str]]:
-
-    def _parse_directory_structure(
-        directory_structure_yaml: list, structure_rule_list: StructureRuleList
-    ) -> str:
-        """Parse directory structure entries and return the description."""
-        if not directory_structure_yaml:
-            raise ConfigurationParseError("Structure rule cannot be empty")
-
-        # First entry must be the description
-        first_entry = directory_structure_yaml[0]
-        if "description" not in first_entry or len(first_entry) != 1:
-            raise ConfigurationParseError(
-                "First entry in structure rule must be a description object "
-                "with only 'description' field"
-            )
-
-        description = first_entry["description"]
-
-        # Parse remaining entries (skip the description at index 0)
-        for item in directory_structure_yaml[1:]:
-            structure_rule_list.append(_parse_entry_to_repo_entry(item))
-
-        return description
-
+    """Parse the ``structure_rules`` section into rules and their descriptions."""
     rules: StructureRuleMap = {}
     descriptions: dict[str, str] = {}
-    if not structure_rules_yaml:
-        return rules, descriptions
 
-    for rule in structure_rules_yaml:
-        structure_rules: StructureRuleList = []
-        description = _parse_directory_structure(
-            structure_rules_yaml[rule], structure_rules
-        )
-        rules[rule] = structure_rules
-        descriptions[rule] = description
+    for rule_name, rule_yaml in structure_rules_yaml.items():
+        description, entries = _take_description(rule_yaml, "Structure rule")
+        rules[rule_name] = [_parse_entry_to_repo_entry(entry) for entry in entries]
+        descriptions[rule_name] = description
+
+    _validate_use_rules(rules)
     return rules, descriptions
+
+
+def _validate_use_rules(rules: StructureRuleMap) -> None:
+    """Reject a ``use_rule`` that names an unknown rule or a different one.
+
+    A ``use_rule`` may only point back at the rule it appears in: it exists to
+    describe recursion, not to compose rules.
+    """
+    for rule_key, entries in rules.items():
+        for entry in entries:
+            if not entry.use_rule:
+                continue
+            if entry.use_rule not in rules:
+                raise ConfigurationParseError(
+                    f"use_rule '{entry.use_rule}' in entry '{entry.path.pattern}'"
+                    "is not a valid rule key"
+                )
+            if entry.use_rule != rule_key:
+                raise ConfigurationParseError(
+                    f"use_rule '{entry.use_rule}' in entry '{entry.path.pattern}'"
+                    "is not recursive"
+                )
 
 
 # The keys that carry an entry's pattern, in precedence order - the first
@@ -383,11 +375,19 @@ _PATTERN_KEYS = ("require", "allow", "forbid")
 
 
 class ParsedEntry(NamedTuple):
-    """A structure rule entry's pattern together with how it is enforced."""
+    """A structure rule entry's pattern together with how it is enforced.
+
+    ``kind`` is the pattern key the entry was written with; what it means for
+    the scan follows from it, so it is derived rather than stored twice.
+    """
 
     pattern: str
     kind: str
-    is_required: bool
+
+    @property
+    def is_required(self) -> bool:
+        """True if the entry's pattern must match at least once."""
+        return self.kind == "require"
 
     @property
     def is_forbidden(self) -> bool:
@@ -399,9 +399,7 @@ def _classify_entry(entry: dict) -> ParsedEntry:
     """Determine which pattern key an entry uses and what it implies."""
     for kind in _PATTERN_KEYS:
         if kind in entry:
-            return ParsedEntry(
-                pattern=entry[kind], kind=kind, is_required=kind == "require"
-            )
+            return ParsedEntry(pattern=entry[kind], kind=kind)
     raise ConfigurationParseError(
         f"Entry must contain one of {', '.join(_PATTERN_KEYS)}: {entry}"
     )
@@ -437,75 +435,79 @@ def _parse_entry_to_repo_entry(entry: dict) -> RepoEntry:
     return result
 
 
+def _substitute_in_entry(entry: dict, expansion_key: str, expansion_var: str) -> dict:
+    """Replace ``{{key}}`` with one expansion value in a single template entry."""
+    if _is_description(entry):
+        return entry
+    kind = _classify_entry(entry).kind
+    entry[kind] = entry[kind].replace(f"{{{{{expansion_key}}}}}", expansion_var)
+    return entry
+
+
 def _expand_template_entry(
     template_yaml: list[dict], expansion_key: str, expansion_var: str
 ) -> list[dict]:
-
-    def _expand_entry(entry: dict, expansion_key: str, expansion_var: str):
-        # Skip description entries
-        if "description" in entry and len(entry) == 1:
-            return entry
-        k = _classify_entry(entry).kind
-        entry[k] = entry[k].replace(f"{{{{{expansion_key}}}}}", expansion_var)
-        return entry
-
+    """Substitute one expansion value throughout a template's entries."""
     expanded_yaml: list[dict] = []
     for entry in template_yaml:
-        entry = _expand_entry(entry, expansion_key, expansion_var)
-        if "if_exists" in entry:
-            entry["if_exists"] = _expand_template_entry(
-                entry["if_exists"], expansion_key, expansion_var
-            )
-        if "companion" in entry:
-            entry["companion"] = _expand_template_entry(
-                entry["companion"], expansion_key, expansion_var
-            )
+        entry = _substitute_in_entry(entry, expansion_key, expansion_var)
+        for nested in ("if_exists", "companion"):
+            if nested in entry:
+                entry[nested] = _expand_template_entry(
+                    entry[nested], expansion_key, expansion_var
+                )
         expanded_yaml.append(entry)
     return expanded_yaml
 
 
-def _parse_use_template(
-    dir_map_yaml: dict, directory: str, templates_yaml: dict, document: ParsedDocument
-):
-    if "use_template" not in dir_map_yaml:
-        return
+def _expand_template(dir_map_yaml: dict, templates_yaml: dict) -> list[dict]:
+    """Instantiate a template once per value of its longest parameter list.
 
-    def _expand_template(dir_map_yaml, templates_yaml):
-        expansion_map = dir_map_yaml["parameters"]
-        max_values_length = max(
-            (len(values) for values in expansion_map.values()), default=0
-        )
-        structure_rules_yaml: list[dict] = []
-        for i in range(max_values_length):
-            if dir_map_yaml["use_template"] not in templates_yaml:
-                raise TemplateError(
-                    f"Template '{dir_map_yaml['use_template']}'"
-                    "not found in templates"
-                )
-            entries = copy.deepcopy(templates_yaml[dir_map_yaml["use_template"]])
-            for expansion_key, expansion_vars in expansion_map.items():
-                index = i % len(expansion_vars)
-                entries = _expand_template_entry(
-                    entries, expansion_key, expansion_vars[index]
-                )
-            structure_rules_yaml.extend(entries)
-        return structure_rules_yaml
+    Parameters shorter than the longest one repeat cyclically, so a template
+    parameterized by two lists of unequal length still yields one entry set per
+    instantiation.
+    """
+    template_name = dir_map_yaml["use_template"]
+    if template_name not in templates_yaml:
+        raise TemplateError(f"Template '{template_name}'" "not found in templates")
+
+    expansion_map = dir_map_yaml["parameters"]
+    instantiations = max((len(values) for values in expansion_map.values()), default=0)
+
+    structure_rules_yaml: list[dict] = []
+    for i in range(instantiations):
+        entries = copy.deepcopy(templates_yaml[template_name])
+        for expansion_key, expansion_vars in expansion_map.items():
+            entries = _expand_template_entry(
+                entries, expansion_key, expansion_vars[i % len(expansion_vars)]
+            )
+        structure_rules_yaml.extend(entries)
+    return structure_rules_yaml
+
+
+def _parse_use_template(
+    dir_map_yaml: dict, directory: str, templates_yaml: dict
+) -> tuple[str, StructureRuleList] | None:
+    """Expand a ``use_template`` entry into a generated rule.
+
+    Returns the generated rule's name and entries, or None if the directory map
+    entry does not use a template at all.
+    """
+    if "use_template" not in dir_map_yaml:
+        return None
 
     structure_rules_yaml = _expand_template(dir_map_yaml, templates_yaml)
-
-    # Filter out description entries before parsing to RepoEntry
-    structure_rule_list = [
-        _parse_entry_to_repo_entry(entry)
-        for entry in structure_rules_yaml
-        if not ("description" in entry and len(entry) == 1)
-    ]
 
     template_rule_name = (
         f"__template_rule_{map_dir_to_rel_dir(directory)}_"
         f"{dir_map_yaml['use_template']}"
     )
-    document.structure_rules[template_rule_name] = structure_rule_list
-    document.directory_map.setdefault(directory, []).append(template_rule_name)
+    entries = [
+        _parse_entry_to_repo_entry(entry)
+        for entry in structure_rules_yaml
+        if not _is_description(entry)
+    ]
+    return template_rule_name, entries
 
 
 def _build_directory_map(
@@ -517,7 +519,7 @@ def _build_directory_map(
     the configurations mounted through ``use_config``, keyed by mount directory.
     """
 
-    def _parse_use_config(rule: dict, directory: str, mounts: dict[str, str]) -> None:
+    def _record_mount(rule: dict, directory: str) -> None:
         if rule.keys() != {"use_config"}:
             return
         if directory in mounts:
@@ -527,40 +529,32 @@ def _build_directory_map(
             )
         mounts[directory] = rule["use_config"]
 
-    def _extract_description(value_list: list) -> str:
-        """Extract and validate description from directory map entry."""
-        if not value_list:
-            raise ConfigurationParseError("Directory map entry cannot be empty")
-
-        first_entry = value_list[0]
-        if "description" not in first_entry or len(first_entry) != 1:
-            raise ConfigurationParseError(
-                "First entry in directory map must be a description"
-                "object with only 'description' field"
-            )
-
-        return first_entry["description"]
-
     mapping: DirectoryMap = {}
     descriptions: dict[str, str] = {}
     mounts: dict[str, str] = {}
 
     for directory, value in directory_map_yaml.items():
-        description = _extract_description(value)
+        description, entries = _take_description(value, "Directory map entry")
         descriptions[directory] = description
 
-        for r in value[1:]:  # Skip the description at index 0
-            if r.keys() == {"use_rule"}:
-                mapping.setdefault(directory, []).append(r["use_rule"])
+        for entry in entries:
+            if entry.keys() == {"use_rule"}:
+                mapping.setdefault(directory, []).append(entry["use_rule"])
             else:
-                _parse_use_config(r, directory, mounts)
+                _record_mount(entry, directory)
 
     return mapping, descriptions, mounts
 
 
-def _parse_templates_to_document(
+def _add_template_rules(
     templates_yaml: dict, directory_map_yaml: dict, document: ParsedDocument
 ) -> None:
+    """Register a generated rule for every ``use_template`` in the directory map."""
     for directory, value in directory_map_yaml.items():
         for use_map in value:
-            _parse_use_template(use_map, directory, templates_yaml, document)
+            expanded = _parse_use_template(use_map, directory, templates_yaml)
+            if expanded is None:
+                continue
+            rule_name, entries = expanded
+            document.structure_rules[rule_name] = entries
+            document.directory_map.setdefault(directory, []).append(rule_name)

--- a/repo_structure/diff_scan.py
+++ b/repo_structure/diff_scan.py
@@ -10,13 +10,13 @@ from .config import (
 )
 
 from .models import (
+    Backlog,
     Entry,
     Flags,
     MatchFailure,
     MatchFailureCode,
     ScanIssue,
     ScanResult,
-    StructureRuleList,
 )
 from .paths import (
     join_path_normalized,
@@ -25,6 +25,7 @@ from .paths import (
     rel_dir_to_map_dir,
 )
 from .scanning import (
+    CompanionIndex,
     check_companion_files,
     child_backlog,
     get_matching_item_index,
@@ -62,6 +63,8 @@ class DiffScanProcessor:
         self.flags = flags if flags is not None else Flags()
         self.repo_root = repo_root
         self.config_file_names = config.configuration_file_names_for(repo_root)
+        # Replaced at the start of every check, so no listing outlives it.
+        self._companions = CompanionIndex()
 
     def _incremental_path_split(
         self, path_to_split: str
@@ -89,7 +92,7 @@ class DiffScanProcessor:
 
     def _check_path_in_backlog(
         self,
-        backlog: StructureRuleList,
+        backlog: Backlog,
         rel_path: str,
         original_path: str,
         map_dir: str,
@@ -138,8 +141,9 @@ class DiffScanProcessor:
             )
             companion_issue = check_companion_files(
                 entry_name,
-                backlog_match,
+                backlog_match.entry,
                 str(Path(self.repo_root) / full_rel_dir),
+                self._companions,
             )
             if companion_issue:
                 # The companion check only knows the entry name; report the
@@ -180,6 +184,11 @@ class DiffScanProcessor:
             Note that this function will not be able to ensure if all required
             entries are present.
         """
+        self._companions = CompanionIndex()
+        return self._check_path(path)
+
+    def _check_path(self, path: str) -> ScanIssue | None:
+        """Check one path against the configuration, reusing the current index."""
         map_dir = self._get_corresponding_map_dir(path)
         base_dir = map_dir_to_rel_dir(map_dir)
         backlog = map_dir_to_entry_backlog(
@@ -204,9 +213,13 @@ class DiffScanProcessor:
             ScanResult holding one error per invalid path. A diff scan cannot
             detect missing required entries, so warnings are always empty.
         """
+        # One index for the whole batch: change sets usually touch the same few
+        # directories, and their companion listings are then read once.
+        self._companions = CompanionIndex()
+
         errors = []
         for path in paths:
-            issue = self.check_path(path)
+            issue = self._check_path(path)
             if issue:
                 errors.append(issue)
         return ScanResult(errors=errors)

--- a/repo_structure/full_scan.py
+++ b/repo_structure/full_scan.py
@@ -14,15 +14,16 @@ from .config_merge import unqualify
 
 from .models import (
     BUILTIN_DIRECTORY_RULES,
+    Backlog,
     Entry,
     Flags,
     MatchFailure,
     ScanIssue,
     ScanResult,
-    StructureRuleList,
 )
 from .paths import join_path_normalized, map_dir_to_rel_dir
 from .scanning import (
+    CompanionIndex,
     check_companion_files,
     child_backlog,
     get_matching_item_index,
@@ -55,6 +56,9 @@ class FullScanProcessor:
         self.flags = flags if flags is not None else Flags()
         self.git_ignore = self._get_git_ignore()
         self.config_file_names = config.configuration_file_names_for(repo_root)
+        # Replaced at the start of every scan, so no listing outlives the scan
+        # that read it.
+        self._companions = CompanionIndex()
 
     def _get_git_ignore(self) -> Callable[[str], bool] | None:
         """Get gitignore parser, cached for the lifetime of the scan.
@@ -72,7 +76,7 @@ class FullScanProcessor:
     def _check_required_entries_missing(
         self,
         rel_dir: str,
-        entry_backlog: StructureRuleList,
+        entry_backlog: Backlog,
     ) -> ScanIssue | None:
 
         def _format_missing_entries_message(
@@ -87,33 +91,28 @@ class FullScanProcessor:
                 result += "".join(f"  - '{dir}'\n" for dir in missing_dirs)
             return result
 
-        missing_required: StructureRuleList = []
-        for entry in entry_backlog:
-            if entry.is_required and entry.count == 0:
-                missing_required.append(entry)
+        missing = [
+            candidate.entry
+            for candidate in entry_backlog
+            if candidate.is_required and candidate.count == 0
+        ]
+        if not missing:
+            return None
 
-        if missing_required:
-            missing_required_files = [
-                f.path.pattern for f in missing_required if not f.is_dir
-            ]
-            missing_required_dirs = [
-                d.path.pattern for d in missing_required if d.is_dir
-            ]
-
-            return ScanIssue(
-                severity="error",
-                code="missing_required_entries",
-                message=_format_missing_entries_message(
-                    missing_required_files, missing_required_dirs
-                ),
-                path=rel_dir,
-            )
-        return None
+        return ScanIssue(
+            severity="error",
+            code="missing_required_entries",
+            message=_format_missing_entries_message(
+                [entry.path.pattern for entry in missing if not entry.is_dir],
+                [entry.path.pattern for entry in missing if entry.is_dir],
+            ),
+            path=rel_dir,
+        )
 
     def _check_reldir_structure(
         self,
         rel_dir: str,
-        backlog: StructureRuleList,
+        backlog: Backlog,
     ) -> list[ScanIssue]:
         """Check repository structure recursively and return list of issues."""
         errors: list[ScanIssue] = []
@@ -141,8 +140,9 @@ class FullScanProcessor:
             # Check for required companion files
             companion_issue = check_companion_files(
                 entry.path,
-                backlog[idx],
+                backlog[idx].entry,
                 str(Path(self.repo_root) / rel_dir),
+                self._companions,
             )
             if companion_issue:
                 errors.append(companion_issue)
@@ -191,7 +191,7 @@ class FullScanProcessor:
         self,
         rel_dir: str,
         entry: Entry,
-        backlog: StructureRuleList,
+        backlog: Backlog,
         idx: int,
     ) -> list[ScanIssue]:
         errors: list[ScanIssue] = []
@@ -294,6 +294,7 @@ class FullScanProcessor:
 
     def scan(self) -> ScanResult:
         """Scan the repository and return the errors and warnings found."""
+        self._companions = CompanionIndex()
         errors = self._collect_errors()
         warnings = self._collect_warnings()
         errors.sort(key=lambda x: (x.path is None, x.path or "", x.code))
@@ -310,4 +311,5 @@ class FullScanProcessor:
             ScanResult for the specified directory mapping. Warnings are always
             empty, since unused-rule detection is repository-wide.
         """
+        self._companions = CompanionIndex()
         return ScanResult(errors=self._process_map_dir(map_dir))

--- a/repo_structure/full_scan_test.py
+++ b/repo_structure/full_scan_test.py
@@ -1504,13 +1504,21 @@ README.md
     assert len(errors) == 0
 
 
-def test_configuration_structure_rules_unmutated_by_scan(tmp_path):
-    """Regression: scanning leaves ``Configuration.structure_rules`` counts at 0."""
+def test_sibling_directories_do_not_share_if_exists_counters(tmp_path):
+    """Regression: each directory gets its own counters for an `if_exists` rule.
+
+    The entries below `if_exists` used to be handed to the scan straight off
+    the configuration, so the first directory to satisfy a required entry
+    bumped the counter every sibling directory was judged by -- and the
+    siblings missing that file were reported as complete.
+    """
     config_yaml = r"""
 structure_rules:
   base_structure:
-    - description: 'Base structure requiring a README'
-    - require: 'README\.md'
+    - description: 'Every directory needs a README'
+    - allow: '.*/'
+      if_exists:
+        - require: 'README\.md'
 directory_map:
   /:
     - description: 'Root directory'
@@ -1520,14 +1528,13 @@ directory_map:
     repo = create_repo_structure(
         tmp_path,
         """
-README.md
+with_readme/
+with_readme/README.md
+without_readme/
 """,
     )
 
-    _check_repo_directory_structure(repo, config)
+    errors, _ = _check_repo_directory_structure(repo, config)
 
-    assert all(
-        entry.count == 0
-        for entries in config.structure_rules.values()
-        for entry in entries
-    )
+    assert [e.code for e in errors] == ["missing_required_entries"]
+    assert errors[0].path == "without_readme"

--- a/repo_structure/models.py
+++ b/repo_structure/models.py
@@ -9,9 +9,13 @@ BUILTIN_DIRECTORY_RULES: Final = (IGNORE_RULE,)
 
 
 @dataclass
-class RepoEntry:  # pylint: disable=too-many-instance-attributes
+class RepoEntry:
     """Wrapper for entries in the directory structure, that store the path
-    as a string together with the entry type."""
+    as a string together with the entry type.
+
+    Owned by the parsed configuration and shared by every scan, so it holds no
+    scan state -- see :class:`BacklogEntry`.
+    """
 
     path: re.Pattern
     is_dir: bool
@@ -20,6 +24,24 @@ class RepoEntry:  # pylint: disable=too-many-instance-attributes
     use_rule: str = ""
     if_exists: list["RepoEntry"] = field(default_factory=list)
     companion: list["RepoEntry"] = field(default_factory=list)
+
+
+@dataclass
+class BacklogEntry:
+    """One entry of the backlog a scan builds for a single directory.
+
+    Wrapping rather than copying the :class:`RepoEntry` keeps the match counter
+    -- the only mutable state a scan keeps -- off the configuration, so two
+    directories governed by the same rule cannot see each other's counts.
+
+    ``is_required`` is carried here rather than read off ``entry`` because a
+    companion pattern joins the backlog as optional even when the rule declares
+    it required: it is enforced against the file that names it, not against the
+    directory as a whole.
+    """
+
+    entry: RepoEntry
+    is_required: bool
     count: int = 0
 
 
@@ -45,6 +67,8 @@ class Flags:
 DirectoryMap = dict[str, list[str]]
 StructureRuleList = list[RepoEntry]
 StructureRuleMap = dict[str, StructureRuleList]
+Backlog = list[BacklogEntry]
+"""The entries a scan checks one directory against, with their match counts."""
 
 INHERIT_ALL: Final = "all"
 

--- a/repo_structure/models_test.py
+++ b/repo_structure/models_test.py
@@ -7,6 +7,7 @@ import re
 from .models import (
     BUILTIN_DIRECTORY_RULES,
     IGNORE_RULE,
+    BacklogEntry,
     Entry,
     Flags,
     MatchFailure,
@@ -31,7 +32,6 @@ class TestRepoEntry:
         assert entry.use_rule == ""
         assert not entry.if_exists
         assert not entry.companion
-        assert entry.count == 0
 
     def test_default_lists_are_not_shared(self):
         """Test that each instance gets its own list instances."""
@@ -43,6 +43,38 @@ class TestRepoEntry:
         )
         first.if_exists.append(second)
         assert not second.if_exists
+
+
+class TestBacklogEntry:
+    """Test the BacklogEntry dataclass."""
+
+    @staticmethod
+    def _entry() -> RepoEntry:
+        return RepoEntry(
+            path=re.compile(r".*\.py"),
+            is_dir=False,
+            is_required=True,
+            is_forbidden=False,
+        )
+
+    def test_counting_is_per_backlog_entry(self):
+        """Test that two backlog entries over one rule entry count separately."""
+        shared = self._entry()
+        first = BacklogEntry(entry=shared, is_required=shared.is_required)
+        second = BacklogEntry(entry=shared, is_required=shared.is_required)
+
+        first.count += 1
+
+        assert first.count == 1
+        assert second.count == 0
+
+    def test_required_can_differ_from_the_rule_entry(self):
+        """Test that a companion may join the backlog as optional."""
+        required_entry = self._entry()
+        candidate = BacklogEntry(entry=required_entry, is_required=False)
+
+        assert required_entry.is_required is True
+        assert candidate.is_required is False
 
 
 class TestEntry:

--- a/repo_structure/patterns.py
+++ b/repo_structure/patterns.py
@@ -98,7 +98,6 @@ def expand_companion_requirements(
             use_rule=template.use_rule,
             if_exists=template.if_exists,
             companion=[],
-            count=0,
         )
         expanded.append(expanded_entry)
 

--- a/repo_structure/report.py
+++ b/repo_structure/report.py
@@ -10,9 +10,9 @@ from .config import Configuration
 from .config_merge import unqualify
 from .models import (
     BUILTIN_DIRECTORY_RULES,
-    DirectoryMap,
     IGNORE_RULE,
-    StructureRuleMap,
+    RepoEntry,
+    StructureRuleList,
 )
 
 ReportFormat = Literal["text", "json", "markdown"]
@@ -134,44 +134,26 @@ def generate_report(config: Configuration, repo_root: str = ".") -> Configuratio
     Returns:
         A complete configuration report with directory and structure rule information.
     """
-    sources = _rule_sources(config)
-
-    directory_reports = _generate_directory_reports(
-        config.directory_map,
-        config.directory_descriptions,
-        config.structure_rule_descriptions,
-    )
-
-    structure_rule_reports = _generate_structure_rule_reports(
-        config.structure_rules,
-        config.directory_map,
-        config.structure_rule_descriptions,
-        config.directory_descriptions,
-        sources,
-    )
-
-    repository_info = get_repository_info(repo_root)
+    directory_reports = _generate_directory_reports(config)
+    structure_rule_reports = _generate_structure_rule_reports(config)
 
     return ConfigurationReport(
         directory_reports=directory_reports,
         structure_rule_reports=structure_rule_reports,
         total_directories=len(directory_reports),
         total_structure_rules=len(structure_rule_reports),
-        repository_info=repository_info,
+        repository_info=get_repository_info(repo_root),
     )
 
 
-def _rule_sources(config: Configuration) -> dict[str, str]:
-    """Map each rule to the mounted configuration that defines it.
+def _rule_source(config: Configuration, rule_name: str) -> str:
+    """Name the mounted configuration a rule comes from, if it is one.
 
-    Rules of the top-level configuration map to the empty string: naming the
+    Rules of the top-level configuration report an empty source: naming the
     file they came from would be noise in a single-file repository.
     """
-    top_level = config.configuration_file_name
-    return {
-        rule_name: "" if origin == top_level else origin
-        for rule_name, origin in config.rule_origins.items()
-    }
+    origin = config.rule_origins.get(rule_name, "")
+    return "" if origin == config.configuration_file_name else origin
 
 
 def _rule_anchor(rule_name: str) -> str:
@@ -184,50 +166,45 @@ def _rule_anchor(rule_name: str) -> str:
     return "rule-" + re.sub(r"[^A-Za-z0-9_-]+", "-", rule_name)
 
 
-def _generate_directory_reports(
-    directory_map: DirectoryMap,
-    directory_descriptions: dict[str, str],
-    structure_rule_descriptions: dict[str, str],
-) -> list[DirectoryReport]:
+_NO_DESCRIPTION = "No description provided"
+_BUILTIN_IGNORE_DESCRIPTION = (
+    "Builtin rule: Excludes this directory from structure validation"
+)
+
+
+def _rule_description(config: Configuration, rule_name: str) -> str:
+    """Describe a rule, covering the builtin rules the configuration cannot."""
+    if rule_name in BUILTIN_DIRECTORY_RULES:
+        return _BUILTIN_IGNORE_DESCRIPTION
+    return config.structure_rule_descriptions.get(rule_name, _NO_DESCRIPTION)
+
+
+def _directory_description(config: Configuration, directory: str) -> str:
+    """Describe a mapped directory."""
+    return config.directory_descriptions.get(directory, _NO_DESCRIPTION)
+
+
+def _generate_directory_reports(config: Configuration) -> list[DirectoryReport]:
     """Generate reports for each directory mapping."""
-    reports = []
-
-    for directory, rules in directory_map.items():
-        rule_descriptions = []
-        for rule in rules:
-            if rule in BUILTIN_DIRECTORY_RULES:
-                rule_descriptions.append(
-                    "Builtin rule: Excludes this directory from structure validation"
-                )
-            else:
-                rule_descriptions.append(
-                    structure_rule_descriptions.get(rule, "No description provided")
-                )
-
-        reports.append(
-            DirectoryReport(
-                directory=directory,
-                description=directory_descriptions.get(
-                    directory, "No description provided"
-                ),
-                applied_rules=rules,
-                rule_descriptions=rule_descriptions,
-            )
+    reports = [
+        DirectoryReport(
+            directory=directory,
+            description=_directory_description(config, directory),
+            applied_rules=rules,
+            rule_descriptions=[_rule_description(config, rule) for rule in rules],
         )
+        for directory, rules in config.directory_map.items()
+    ]
 
     return sorted(reports, key=lambda x: x.directory)
 
 
 def _generate_structure_rule_reports(
-    structure_rules: StructureRuleMap,
-    directory_map: DirectoryMap,
-    structure_rule_descriptions: dict[str, str],
-    directory_descriptions: dict[str, str],
-    rule_sources: dict[str, str],
+    config: Configuration,
 ) -> list[StructureRuleReport]:
     """Generate reports for each structure rule."""
 
-    def _format_pattern(entry) -> str:
+    def _format_pattern(entry: RepoEntry) -> str:
         """Format a RepoEntry as a human-readable pattern string."""
         # Determine the pattern type
         if entry.is_forbidden:
@@ -261,59 +238,37 @@ def _generate_structure_rule_reports(
 
         return result
 
-    reports = []
-
-    # Check if the ignore rule is used anywhere
-    ignore_directories = [
-        directory for directory, rules in directory_map.items() if IGNORE_RULE in rules
-    ]
-
-    # Add built-in ignore rule if it's used
-    if ignore_directories:
-        directory_descs = [
-            directory_descriptions.get(directory, "No description provided")
-            for directory in ignore_directories
-        ]
-        reports.append(
-            StructureRuleReport(
-                rule_name=IGNORE_RULE,
-                description="Builtin rule: Excludes this directory from structure validation",
-                applied_directories=ignore_directories,
-                directory_descriptions=directory_descs,
-                rule_count=0,
-                patterns=[],
-            )
-        )
-
-    for rule_name, rule_entries in structure_rules.items():
-        # Find directories that use this rule
-        applied_directories = [
+    def _directories_using(rule_name: str) -> list[str]:
+        return [
             directory
-            for directory, rules in directory_map.items()
+            for directory, rules in config.directory_map.items()
             if rule_name in rules
         ]
 
-        directory_descs = [
-            directory_descriptions.get(directory, "No description provided")
-            for directory in applied_directories
-        ]
-
-        # Format patterns from rule entries
-        patterns = [_format_pattern(entry) for entry in rule_entries]
-
-        reports.append(
-            StructureRuleReport(
-                rule_name=rule_name,
-                description=structure_rule_descriptions.get(
-                    rule_name, "No description provided"
-                ),
-                applied_directories=applied_directories,
-                directory_descriptions=directory_descs,
-                rule_count=len(rule_entries),
-                patterns=patterns,
-                source_config=rule_sources.get(rule_name, ""),
-            )
+    def _report_for(rule_name: str, entries: StructureRuleList) -> StructureRuleReport:
+        applied_directories = _directories_using(rule_name)
+        return StructureRuleReport(
+            rule_name=rule_name,
+            description=_rule_description(config, rule_name),
+            applied_directories=applied_directories,
+            directory_descriptions=[
+                _directory_description(config, directory)
+                for directory in applied_directories
+            ],
+            rule_count=len(entries),
+            patterns=[_format_pattern(entry) for entry in entries],
+            source_config=_rule_source(config, rule_name),
         )
+
+    reports = [
+        _report_for(rule_name, entries)
+        for rule_name, entries in config.structure_rules.items()
+    ]
+
+    # The builtin ignore rule has no entry in structure_rules, so it only shows
+    # up in the report when some directory actually maps it.
+    if _directories_using(IGNORE_RULE):
+        reports.append(_report_for(IGNORE_RULE, []))
 
     return sorted(reports, key=lambda x: x.rule_name)
 
@@ -486,53 +441,47 @@ def _format_repository_info_markdown(repo_info: RepositoryInfo) -> list[str]:
     return lines
 
 
-def format_report_markdown(report: ConfigurationReport) -> str:
-    """Format the report as Markdown.
+_MARKDOWN_INTRODUCTION = [
+    "## Introduction",
+    "",
+    "This report provides a comprehensive view of your repository's "
+    "structure validation configuration. "
+    "It shows how directories are mapped to rules and what those rules enforce.",
+    "",
+    "**Directory Maps** define which structure rules apply to specific "
+    "directories in your repository. "
+    "They map directory paths to the validation rules that govern their contents.",
+    "",
+    "**Structure Rules** specify what files and directories are allowed, "
+    "required, or forbidden within a directory. "
+    "Each rule consists of patterns that match against file paths using "
+    "[Python regular expressions]"
+    "(https://docs.python.org/3/library/re.html#regular-expression-syntax).",
+    "",
+]
+
+
+def _directory_anchor(directory: str) -> str:
+    """Build the markdown anchor id of a directory section."""
+    return "dir-" + (directory.strip("/").replace("/", "-") or "root")
+
+
+def _format_directory_mappings_markdown(
+    directory_reports: list[DirectoryReport],
+) -> list[str]:
+    """Format directory mappings section for markdown output.
 
     Args:
-        report: The configuration report to format.
+        directory_reports: List of directory reports to format
 
     Returns:
-        A Markdown representation of the report.
+        List of formatted markdown lines
     """
-    lines = []
-    lines.append("# Repository Structure Configuration Report")
-    lines.append("")
-
-    lines.append("## Introduction")
-    lines.append("")
-    lines.append(
-        "This report provides a comprehensive view of your repository's "
-        "structure validation configuration. "
-        "It shows how directories are mapped to rules and what those rules enforce."
-    )
-    lines.append("")
-    lines.append(
-        "**Directory Maps** define which structure rules apply to specific "
-        "directories in your repository. "
-        "They map directory paths to the validation rules that govern their contents."
-    )
-    lines.append("")
-    lines.append(
-        "**Structure Rules** specify what files and directories are allowed, "
-        "required, or forbidden within a directory. "
-        "Each rule consists of patterns that match against file paths using "
-        "[Python regular expressions]"
-        "(https://docs.python.org/3/library/re.html#regular-expression-syntax)."
-    )
-    lines.append("")
-
-    if report.repository_info:
-        lines.extend(_format_repository_info_markdown(report.repository_info))
-
-    # Directory dimension
-    lines.append("## Directory Mappings")
-    lines.append("")
-    for dir_report in report.directory_reports:
+    lines = ["## Directory Mappings", ""]
+    for dir_report in directory_reports:
         display_dir = _normalize_directory_display(dir_report.directory)
-        # Create anchor for this directory
-        dir_anchor = dir_report.directory.strip("/").replace("/", "-") or "root"
-        lines.append(f"### Directory: `{display_dir}` {{#dir-{dir_anchor}}}")
+        anchor = _directory_anchor(dir_report.directory)
+        lines.append(f"### Directory: `{display_dir}` {{#{anchor}}}")
         lines.append("")
         lines.append(f"**Description:** {dir_report.description}")
         lines.append("")
@@ -541,12 +490,22 @@ def format_report_markdown(report: ConfigurationReport) -> str:
             # Link to the rule section
             lines.append(f"- [`{unqualify(rule)}`](#{_rule_anchor(rule)}): {desc}")
         lines.append("")
+    return lines
 
-    # Structure rule dimension
-    lines.append("## Structure Rules")
-    lines.append("")
-    for rule_report in report.structure_rule_reports:
-        # Create anchor for this rule
+
+def _format_structure_rules_markdown(
+    structure_rule_reports: list[StructureRuleReport],
+) -> list[str]:
+    """Format structure rules section for markdown output.
+
+    Args:
+        structure_rule_reports: List of structure rule reports to format
+
+    Returns:
+        List of formatted markdown lines
+    """
+    lines = ["## Structure Rules", ""]
+    for rule_report in structure_rule_reports:
         display_name = unqualify(rule_report.rule_name)
         lines.append(
             f"### Rule: `{display_name}` {{#{_rule_anchor(rule_report.rule_name)}}}"
@@ -562,11 +521,8 @@ def format_report_markdown(report: ConfigurationReport) -> str:
             lines.append(f"**Entry Count:** {rule_report.rule_count}")
             lines.append("")
             lines.append("**Patterns:**")
-            for pattern in rule_report.patterns:
-                lines.append(f"- `{pattern}`")
-            lines.append("")
-        else:
-            lines.append("")
+            lines.extend(f"- `{pattern}`" for pattern in rule_report.patterns)
+        lines.append("")
 
         lines.append("**Applied to Directories:**")
         for directory, desc in zip(
@@ -574,9 +530,30 @@ def format_report_markdown(report: ConfigurationReport) -> str:
         ):
             display_dir = _normalize_directory_display(directory)
             # Link back to the directory section
-            dir_anchor = directory.strip("/").replace("/", "-") or "root"
-            lines.append(f"- [`{display_dir}`](#dir-{dir_anchor}): {desc}")
+            lines.append(
+                f"- [`{display_dir}`](#{_directory_anchor(directory)}): {desc}"
+            )
         lines.append("")
+    return lines
+
+
+def format_report_markdown(report: ConfigurationReport) -> str:
+    """Format the report as Markdown.
+
+    Args:
+        report: The configuration report to format.
+
+    Returns:
+        A Markdown representation of the report.
+    """
+    lines = ["# Repository Structure Configuration Report", ""]
+    lines.extend(_MARKDOWN_INTRODUCTION)
+
+    if report.repository_info:
+        lines.extend(_format_repository_info_markdown(report.repository_info))
+
+    lines.extend(_format_directory_mappings_markdown(report.directory_reports))
+    lines.extend(_format_structure_rules_markdown(report.structure_rule_reports))
 
     return "\n".join(lines)
 

--- a/repo_structure/scanning.py
+++ b/repo_structure/scanning.py
@@ -9,6 +9,8 @@ from typing import Callable
 
 from .models import (
     BUILTIN_DIRECTORY_RULES,
+    Backlog,
+    BacklogEntry,
     DirectoryMap,
     Entry,
     Flags,
@@ -17,7 +19,6 @@ from .models import (
     MatchSuccess,
     RepoEntry,
     ScanIssue,
-    StructureRuleList,
     StructureRuleMap,
 )
 from .paths import (
@@ -85,8 +86,8 @@ def to_entry(os_entry: DirEntry[str], rel_dir: str) -> Entry:
 
 
 def child_backlog(
-    backlog_entry: RepoEntry, structure_rules: StructureRuleMap
-) -> StructureRuleList | None:
+    matched: BacklogEntry, structure_rules: StructureRuleMap
+) -> Backlog | None:
     """Build the backlog that applies inside a matched directory entry.
 
     A directory entry either recurses into a structure rule via ``use_rule`` or
@@ -94,15 +95,18 @@ def child_backlog(
     decides what is allowed below it. Returns None when neither does, meaning
     the directory's contents are not described at all.
     """
-    if backlog_entry.use_rule:
-        _LOGGER.debug("use_rule found for '%s'", backlog_entry.path.pattern)
+    entry = matched.entry
+    if entry.use_rule:
+        _LOGGER.debug("use_rule found for '%s'", entry.path.pattern)
         return _build_active_entry_backlog(
-            [backlog_entry.use_rule],
+            [entry.use_rule],
             structure_rules,
         )
-    if backlog_entry.if_exists:
-        _LOGGER.debug("if_exists found for '%s'", backlog_entry.path.pattern)
-        return backlog_entry.if_exists
+    if entry.if_exists:
+        _LOGGER.debug("if_exists found for '%s'", entry.path.pattern)
+        # A fresh backlog per matched directory: sibling directories governed
+        # by the same `if_exists` must not share match counts.
+        return [_to_backlog_entry(child) for child in entry.if_exists]
     return None
 
 
@@ -110,111 +114,108 @@ def map_dir_to_entry_backlog(
     directory_map: DirectoryMap,
     structure_rules: StructureRuleMap,
     map_dir: str,
-) -> StructureRuleList:
+) -> Backlog:
     """Get the active entry backlog for a given mapped directory."""
-
-    def _get_use_rules_for_directory(
-        directory_map: DirectoryMap, directory: str
-    ) -> list[str]:
-        d = rel_dir_to_map_dir(directory)
-        return directory_map[d]
-
-    use_rules = _get_use_rules_for_directory(directory_map, map_dir)
+    use_rules = directory_map[rel_dir_to_map_dir(map_dir)]
     return _build_active_entry_backlog(use_rules, structure_rules)
 
 
-def _clone_repo_entry(
+def _to_backlog_entry(
     entry: RepoEntry, *, is_required: bool | None = None
-) -> RepoEntry:
-    """Shallow-clone a RepoEntry with count reset to 0.
-
-    Counters live on the per-scan backlog. Cloning prevents scan state from
-    leaking back into the shared Configuration.
-    """
-    return RepoEntry(
-        path=entry.path,
-        is_dir=entry.is_dir,
-        is_required=is_required if is_required is not None else entry.is_required,
-        is_forbidden=entry.is_forbidden,
-        use_rule=entry.use_rule,
-        if_exists=entry.if_exists,
-        companion=entry.companion,
-        count=0,
+) -> BacklogEntry:
+    """Put a configured entry on a backlog, with a match counter of its own."""
+    return BacklogEntry(
+        entry=entry,
+        is_required=entry.is_required if is_required is None else is_required,
     )
 
 
 def _build_active_entry_backlog(
     active_use_rules: list[str], structure_rules: StructureRuleMap
-) -> StructureRuleList:
-    result: StructureRuleList = []
+) -> Backlog:
+    result: Backlog = []
     for rule in active_use_rules:
         if rule in BUILTIN_DIRECTORY_RULES:
             continue
-        rules = structure_rules[rule]
-        # Clone every entry so scan-time mutations (count += 1) do not leak
-        # back into Configuration.structure_rules.
-        result.extend(_clone_repo_entry(entry) for entry in rules)
-
-        # Add companions without template substitution to initial backlog
-        for entry in rules:
-            if entry.companion:
-                for companion in entry.companion:
-                    # Only add if no template substitution needed
-                    if not has_template_substitution(companion.path.pattern):
-                        companion_copy = _clone_repo_entry(companion, is_required=False)
-                        result.append(companion_copy)
+        for entry in structure_rules[rule]:
+            result.append(_to_backlog_entry(entry))
+            # Companions that need no template substitution are allowed
+            # outright; the ones that do are checked against the file whose
+            # captures expand them, so they never join the backlog.
+            result.extend(
+                _to_backlog_entry(companion, is_required=False)
+                for companion in entry.companion
+                if not has_template_substitution(companion.path.pattern)
+            )
     return result
 
 
 def get_matching_item_index(
-    backlog: StructureRuleList,
+    backlog: Backlog,
     entry_path: str,
     is_dir: bool,
 ) -> MatchResult:
     """Get matching item index without raising exceptions, return result with potential issues."""
-    for i, v in enumerate(backlog):
-        if v.path.fullmatch(entry_path) and v.is_dir == is_dir:
-            if v.is_forbidden:
+    for i, candidate in enumerate(backlog):
+        entry = candidate.entry
+        if entry.path.fullmatch(entry_path) and entry.is_dir == is_dir:
+            if entry.is_forbidden:
                 return MatchFailure(
                     code="forbidden_entry", entry_path=entry_path, is_dir=is_dir
                 )
-            _LOGGER.debug("  Found match at index %d: '%s'", i, v.path.pattern)
+            _LOGGER.debug("  Found match at index %d: '%s'", i, entry.path.pattern)
             return MatchSuccess(index=i)
 
     return MatchFailure(code="unspecified_entry", entry_path=entry_path, is_dir=is_dir)
 
 
-def _find_matching_file_in_directory(base_dir: str, pattern: re.Pattern) -> bool:
-    """Find a file matching the pattern in the directory tree.
-
-    Args:
-        base_dir: Base directory to search in
-        pattern: Compiled regex pattern to match against
-
-    Returns:
-        True if a matching file is found, False otherwise
-    """
+def _list_files_below(base_dir: str) -> list[str]:
+    """List every file below ``base_dir``, as normalized relative paths."""
     base_path = Path(base_dir)
     if not base_path.is_dir():
-        return False
+        return []
 
-    for root, _dirs, files in os.walk(base_dir):
-        for filename in files:
-            file_abs = Path(root) / filename
-            file_rel = file_abs.relative_to(base_path)
-            file_rel_normalized = normalize_path(str(file_rel))
+    return [
+        normalize_path(str((Path(root) / filename).relative_to(base_path)))
+        for root, _dirs, files in os.walk(base_dir)
+        for filename in files
+    ]
 
-            if pattern.fullmatch(file_rel_normalized):
-                _LOGGER.debug("  Found companion: %s", file_rel_normalized)
+
+class CompanionIndex:  # pylint: disable=too-few-public-methods
+    """Directory listings shared by the companion checks of one scan.
+
+    A companion is searched for anywhere below the directory of the file that
+    names it, so every check walks a whole subtree. Since a directory of N
+    modules each requiring a companion asks about the same subtree N times,
+    the listing is walked once and answered from memory afterwards.
+
+    Deliberately scoped to a single scan: a longer-lived index would answer
+    from a listing the filesystem has since moved on from.
+    """
+
+    def __init__(self) -> None:
+        self._listings: dict[str, list[str]] = {}
+
+    def contains_match(self, base_dir: str, pattern: re.Pattern) -> bool:
+        """Return True if any file below ``base_dir`` fully matches ``pattern``."""
+        listing = self._listings.get(base_dir)
+        if listing is None:
+            listing = _list_files_below(base_dir)
+            self._listings[base_dir] = listing
+
+        for rel_path in listing:
+            if pattern.fullmatch(rel_path):
+                _LOGGER.debug("  Found companion: %s", rel_path)
                 return True
-
-    return False
+        return False
 
 
 def check_companion_files(
     entry_name: str,
     matched_entry: RepoEntry,
     search_dir: str,
+    companions: CompanionIndex,
 ) -> ScanIssue | None:
     """Check if required companion files exist for a matched entry.
 
@@ -223,6 +224,7 @@ def check_companion_files(
         matched_entry: The RepoEntry that was matched
         search_dir: Directory to search companions in, resolved by the caller
             against the repository root (not the process CWD)
+        companions: Directory listings for the scan in progress
 
     Returns:
         ScanIssue if a required companion is missing, None otherwise
@@ -248,7 +250,7 @@ def check_companion_files(
             continue
 
         # Search for file matching the companion pattern
-        if not _find_matching_file_in_directory(base_dir, companion.path):
+        if not companions.contains_match(base_dir, companion.path):
             _LOGGER.debug(
                 "  Missing companion matching pattern: %s", companion.path.pattern
             )

--- a/repo_structure/scanning_test.py
+++ b/repo_structure/scanning_test.py
@@ -5,7 +5,7 @@
 import re
 from unittest.mock import Mock
 
-from .models import Entry, Flags, MatchSuccess, RepoEntry
+from .models import BacklogEntry, Entry, Flags, MatchSuccess, RepoEntry
 from .scanning import (
     _build_active_entry_backlog,
     child_backlog,
@@ -139,50 +139,37 @@ class TestToEntry:
         assert entry.is_symlink is False
 
 
+def _backlog(pattern: str, *, is_dir: bool = False, **kwargs) -> list[BacklogEntry]:
+    """Build a one-element backlog around a freshly compiled pattern."""
+    entry = RepoEntry(
+        path=re.compile(pattern),
+        is_dir=is_dir,
+        is_required=False,
+        is_forbidden=False,
+        **kwargs,
+    )
+    return [BacklogEntry(entry=entry, is_required=entry.is_required)]
+
+
 class TestGetMatchingItemIndex:
     """Test the get_matching_item_index function."""
 
     def test_get_matching_item_index_found_file(self):
         """Test finding a matching file entry."""
-        backlog = [
-            RepoEntry(
-                path=re.compile(r"file\.txt"),
-                is_dir=False,
-                is_required=False,
-                is_forbidden=False,
-            )
-        ]
-
-        result = get_matching_item_index(backlog, "file.txt", False)
+        result = get_matching_item_index(_backlog(r"file\.txt"), "file.txt", False)
         assert result == MatchSuccess(index=0)
 
     def test_get_matching_item_index_found_directory(self):
         """Test finding a matching directory entry."""
-        backlog = [
-            RepoEntry(
-                path=re.compile(r"subdir"),
-                is_dir=True,
-                is_required=False,
-                is_forbidden=False,
-            )
-        ]
-
-        result = get_matching_item_index(backlog, "subdir", True)
+        result = get_matching_item_index(
+            _backlog(r"subdir", is_dir=True), "subdir", True
+        )
         assert result == MatchSuccess(index=0)
 
     def test_get_matching_item_index_verbose_output(self, caplog):
         """Test verbose output when finding a match."""
-        backlog = [
-            RepoEntry(
-                path=re.compile(r"file\.txt"),
-                is_dir=False,
-                is_required=False,
-                is_forbidden=False,
-            )
-        ]
-
         with caplog.at_level("DEBUG", logger=_SCANNING_LOGGER):
-            get_matching_item_index(backlog, "file.txt", False)
+            get_matching_item_index(_backlog(r"file\.txt"), "file.txt", False)
         assert "Found match at index 0: 'file\\.txt'" in caplog.text
 
 
@@ -190,14 +177,8 @@ class TestChildBacklog:
     """Test the child_backlog function."""
 
     @staticmethod
-    def _dir_entry(pattern: str, **kwargs) -> RepoEntry:
-        return RepoEntry(
-            path=re.compile(pattern),
-            is_dir=True,
-            is_required=False,
-            is_forbidden=False,
-            **kwargs,
-        )
+    def _dir_entry(pattern: str, **kwargs) -> BacklogEntry:
+        return _backlog(pattern, is_dir=True, **kwargs)[0]
 
     def test_child_backlog_from_use_rule(self):
         """Test that use_rule expands into the referenced rule's entries."""
@@ -217,7 +198,7 @@ class TestChildBacklog:
         )
         assert result is not None
         assert len(result) == 1
-        assert result[0].path.pattern == ".*\\.py"
+        assert result[0].entry.path.pattern == ".*\\.py"
 
     def test_child_backlog_from_if_exists(self):
         """Test that if_exists is used when no use_rule is given."""
@@ -231,7 +212,8 @@ class TestChildBacklog:
         ]
 
         result = child_backlog(self._dir_entry(r".*", if_exists=if_exists_entries), {})
-        assert result == if_exists_entries
+        assert result is not None
+        assert [candidate.entry for candidate in result] == if_exists_entries
 
     def test_child_backlog_without_rules(self):
         """Test that an entry with neither use_rule nor if_exists expands to None."""
@@ -281,7 +263,7 @@ class TestBuildActiveEntryBacklog:
 
         result = _build_active_entry_backlog(["python_files"], structure_rules)
         assert len(result) == 1
-        assert result[0].path.pattern == ".*\\.py"
+        assert result[0].entry.path.pattern == ".*\\.py"
 
     def test_build_active_entry_backlog_multiple_rules(self):
         """Test building backlog with multiple rules."""
@@ -326,7 +308,7 @@ class TestBuildActiveEntryBacklog:
             ["ignore", "python_files"], structure_rules
         )
         assert len(result) == 1
-        assert result[0].path.pattern == ".*\\.py"
+        assert result[0].entry.path.pattern == ".*\\.py"
 
     def test_build_active_entry_backlog_empty_rules(self):
         """Test building backlog with empty rules list."""
@@ -363,4 +345,4 @@ class TestMapDirToEntryBacklog:
 
         result = map_dir_to_entry_backlog(directory_map, structure_rules, "/app/")
         assert len(result) == 1
-        assert result[0].path.pattern == ".*\\.py"
+        assert result[0].entry.path.pattern == ".*\\.py"


### PR DESCRIPTION
Second of three stacked PRs. **Stacked on #218 — review that first; this diff is against it.**

Design work on top of the Tier 1 cleanups. One of these is a correctness fix.

## Scan state no longer lives on the configuration

`RepoEntry.count` was per-scan mutable state stored on objects the `Configuration` owns and every scan shares. `_clone_repo_entry` defended the `use_rule` path against the resulting aliasing, but the `if_exists` path handed the configuration's own entries to the scan unguarded, so **sibling directories governed by one `if_exists` rule shared a single counter**:

```yaml
structure_rules:
  base:
    - description: 'every directory needs a README'
    - allow: '.*/'
      if_exists:
        - require: 'README\.md'
```

The first directory containing a README bumped the counter every other directory was judged by, and the directories missing one were reported as complete. The same aliasing also leaked across two scans that share a `Configuration`.

Counters now live on a `BacklogEntry` wrapper built per directory, so the sharing is structurally impossible rather than defended against, and the clone helper is gone. Regression test included.

## Companion lookups no longer rescan the tree per file

Each required companion ran a fresh `os.walk` of the subtree below the matched file, so a directory of N modules each requiring a companion walked the same tree N times. A `CompanionIndex` scoped to one scan walks each subtree once. Measured on a flat directory of plain modules:

| modules | walk per lookup | memoized | speedup |
|--------:|----------------:|---------:|--------:|
| 150     | 348 ms          | 6.7 ms   | 52×     |
| 400     | 2439 ms         | 26.6 ms  | 92×     |

The growth confirms quadratic became linear. A companion-heavy benchmark case covers it. The "search below the matched file's directory" semantics are unchanged — the index only memoizes the listing.

## Also

- The config parser returns values instead of filling out-parameters, the "first entry is the description" rule is read by one shared helper instead of two near-identical copies, and single-use nested `def`s are module-level privates.
- Report generation takes the `Configuration` once instead of five parallel collections unpacked from it, and the markdown formatter is split into the same section helpers the text formatter already had.

## Verification

- `uv run --extra dev pytest` — 268 passed; `uv run prek run --all-files` clean; `uv run repo_structure full-scan` succeeds
- Text, JSON and markdown report output diffed **byte-identical** against the pre-refactor code

🤖 Generated with [Claude Code](https://claude.com/claude-code)